### PR TITLE
Add TextFieldPreference & Rework existing implementations

### DIFF
--- a/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/model/PreferenceDataEvaluatorScope.kt
+++ b/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/model/PreferenceDataEvaluatorScope.kt
@@ -20,13 +20,7 @@ import androidx.compose.runtime.Composable
 
 typealias PreferenceDataEvaluator = @Composable PreferenceDataEvaluatorScope.() -> Boolean
 
-class PreferenceDataEvaluatorScope {
-    companion object {
-        private val staticInstance = PreferenceDataEvaluatorScope()
-
-        fun instance() = staticInstance
-    }
-
+object PreferenceDataEvaluatorScope {
     @Composable
     infix fun <V : Any> PreferenceData<V>.isEqualTo(other: PreferenceData<V>): Boolean {
         val pref1 = this.observeAsState()

--- a/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/DialogSliderPreference.kt
+++ b/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/DialogSliderPreference.kt
@@ -16,7 +16,6 @@
 
 package dev.patrickgold.jetpref.datastore.ui
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -35,21 +34,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.semantics.Role
 import dev.patrickgold.jetpref.datastore.model.PreferenceData
 import dev.patrickgold.jetpref.datastore.model.PreferenceDataEvaluator
-import dev.patrickgold.jetpref.datastore.model.PreferenceDataEvaluatorScope
-import dev.patrickgold.jetpref.datastore.model.PreferenceModel
 import dev.patrickgold.jetpref.datastore.model.observeAsState
 import dev.patrickgold.jetpref.material.ui.JetPrefAlertDialog
-import dev.patrickgold.jetpref.material.ui.JetPrefListItem
 import kotlin.math.round
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 
 @ExperimentalJetPrefDatastoreUi
 @Composable
-internal fun <T : PreferenceModel, V> PreferenceUiScope<T>.DialogSliderPreference(
+internal fun <V> DialogSliderPreference(
     pref: PreferenceData<V>,
     modifier: Modifier,
     icon: ImageVector? = null,
@@ -73,65 +68,60 @@ internal fun <T : PreferenceModel, V> PreferenceUiScope<T>.DialogSliderPreferenc
     var sliderValue by remember { mutableFloatStateOf(0.0f) }
     var isDialogOpen by remember { mutableStateOf(false) }
 
-    val evalScope = PreferenceDataEvaluatorScope.instance()
-    if (this.visibleIf(evalScope) && visibleIf(evalScope)) {
-        val isEnabled = this.enabledIf(evalScope) && enabledIf(evalScope)
-        JetPrefListItem(
-            modifier = modifier
-                .clickable(
-                    enabled = isEnabled,
-                    role = Role.Button,
-                    onClick = {
-                        sliderValue = prefValue.toFloat()
-                        isDialogOpen = true
-                    }
-                ),
-            icon = maybeJetIcon(imageVector = icon, iconSpaceReserved = iconSpaceReserved),
-            text = title,
-            secondaryText = summary(prefValue),
-            enabled = isEnabled,
-        )
-        if (isDialogOpen) {
-            JetPrefAlertDialog(
-                title = title,
-                confirmLabel = dialogStrings.confirmLabel,
-                onConfirm = {
-                    pref.set(convertToV(sliderValue))
-                    isDialogOpen = false
-                },
-                dismissLabel = dialogStrings.dismissLabel,
-                onDismiss = {
-                    isDialogOpen = false
-                },
-                neutralLabel = dialogStrings.neutralLabel,
-                onNeutral = {
-                    pref.reset()
-                    isDialogOpen = false
-                },
-            ) {
-                Column {
-                    Text(
-                        text = valueLabel(convertToV(sliderValue)),
-                        modifier = Modifier.align(Alignment.CenterHorizontally),
-                    )
-                    Slider(
-                        value = sliderValue,
-                        valueRange = min.toFloat()..max.toFloat(),
-                        steps = ((max.toFloat() - min.toFloat()) / stepIncrement.toFloat()).roundToInt() - 1,
-                        onValueChange = { sliderValue = round(it) },
-                        onValueChangeFinished = { onPreviewSelectedValue(convertToV(sliderValue)) },
-                        colors = SliderDefaults.colors(
-                            thumbColor = MaterialTheme.colorScheme.primary,
-                            activeTrackColor = MaterialTheme.colorScheme.primary,
-                            activeTickColor = Color.Transparent,
-                            inactiveTrackColor = MaterialTheme.colorScheme.onSurface.copy(
-                                alpha = SliderDefaults.colors().inactiveTrackColor.alpha,
-                            ),
-                            inactiveTickColor = Color.Transparent,
+    Preference(
+        modifier = modifier,
+        icon = icon,
+        iconSpaceReserved = iconSpaceReserved,
+        title = title,
+        summary = summary(prefValue),
+        enabledIf = enabledIf,
+        visibleIf = visibleIf,
+        onClick = {
+            sliderValue = prefValue.toFloat()
+            isDialogOpen = true
+        },
+    )
+
+    if (isDialogOpen) {
+        JetPrefAlertDialog(
+            title = title,
+            confirmLabel = dialogStrings.confirmLabel,
+            onConfirm = {
+                pref.set(convertToV(sliderValue))
+                isDialogOpen = false
+            },
+            dismissLabel = dialogStrings.dismissLabel,
+            onDismiss = {
+                isDialogOpen = false
+            },
+            neutralLabel = dialogStrings.neutralLabel,
+            onNeutral = {
+                pref.reset()
+                isDialogOpen = false
+            },
+        ) {
+            Column {
+                Text(
+                    text = valueLabel(convertToV(sliderValue)),
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                )
+                Slider(
+                    value = sliderValue,
+                    valueRange = min.toFloat()..max.toFloat(),
+                    steps = ((max.toFloat() - min.toFloat()) / stepIncrement.toFloat()).roundToInt() - 1,
+                    onValueChange = { sliderValue = round(it) },
+                    onValueChangeFinished = { onPreviewSelectedValue(convertToV(sliderValue)) },
+                    colors = SliderDefaults.colors(
+                        thumbColor = MaterialTheme.colorScheme.primary,
+                        activeTrackColor = MaterialTheme.colorScheme.primary,
+                        activeTickColor = Color.Transparent,
+                        inactiveTrackColor = MaterialTheme.colorScheme.onSurface.copy(
+                            alpha = SliderDefaults.colors().inactiveTrackColor.alpha,
                         ),
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                }
+                        inactiveTickColor = Color.Transparent,
+                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                )
             }
         }
     }
@@ -139,7 +129,7 @@ internal fun <T : PreferenceModel, V> PreferenceUiScope<T>.DialogSliderPreferenc
 
 @ExperimentalJetPrefDatastoreUi
 @Composable
-internal fun <T : PreferenceModel, V> PreferenceUiScope<T>.DialogSliderPreference(
+internal fun <V> DialogSliderPreference(
     primaryPref: PreferenceData<V>,
     secondaryPref: PreferenceData<V>,
     modifier: Modifier,
@@ -169,95 +159,90 @@ internal fun <T : PreferenceModel, V> PreferenceUiScope<T>.DialogSliderPreferenc
     var secondarySliderValue by remember { mutableStateOf(convertToV(0.0f)) }
     var isDialogOpen by remember { mutableStateOf(false) }
 
-    val evalScope = PreferenceDataEvaluatorScope.instance()
-    if (this.visibleIf(evalScope) && visibleIf(evalScope)) {
-        val isEnabled = this.enabledIf(evalScope) && enabledIf(evalScope)
-        JetPrefListItem(
-            modifier = modifier
-                .clickable(
-                    enabled = isEnabled,
-                    role = Role.Button,
-                    onClick = {
-                        primarySliderValue = primaryPrefValue
-                        secondarySliderValue = secondaryPrefValue
-                        isDialogOpen = true
-                    }
-                ),
-            icon = maybeJetIcon(imageVector = icon, iconSpaceReserved = iconSpaceReserved),
-            text = title,
-            secondaryText = summary(primaryPrefValue, secondaryPrefValue),
-            enabled = isEnabled,
-        )
-        if (isDialogOpen) {
-            JetPrefAlertDialog(
-                title = title,
-                confirmLabel = dialogStrings.confirmLabel,
-                onConfirm = {
-                    primaryPref.set(primarySliderValue)
-                    secondaryPref.set(secondarySliderValue)
-                    isDialogOpen = false
-                },
-                dismissLabel = dialogStrings.dismissLabel,
-                onDismiss = {
-                    isDialogOpen = false
-                },
-                neutralLabel = dialogStrings.neutralLabel,
-                onNeutral = {
-                    primaryPref.reset()
-                    secondaryPref.reset()
-                    isDialogOpen = false
-                },
-            ) {
-                Column {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                    ) {
-                        Text(primaryLabel)
-                        Text(valueLabel(primarySliderValue))
-                    }
-                    Slider(
-                        value = primarySliderValue.toFloat(),
-                        valueRange = min.toFloat()..max.toFloat(),
-                        steps = ((max.toFloat() - min.toFloat()) / stepIncrement.toFloat()).toInt() - 1,
-                        onValueChange = { primarySliderValue = convertToV(it) },
-                        onValueChangeFinished = { onPreviewSelectedPrimaryValue(primarySliderValue) },
-                        colors = SliderDefaults.colors(
-                            thumbColor = MaterialTheme.colorScheme.primary,
-                            activeTrackColor = MaterialTheme.colorScheme.primary,
-                            activeTickColor = Color.Transparent,
-                            inactiveTrackColor = MaterialTheme.colorScheme.onSurface.copy(
-                                alpha = SliderDefaults.colors().inactiveTrackColor.alpha,
-                            ),
-                            inactiveTickColor = Color.Transparent,
-                        ),
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                    ) {
-                        Text(secondaryLabel)
-                        Text(valueLabel(secondarySliderValue))
-                    }
-                    Slider(
-                        value = secondarySliderValue.toFloat(),
-                        valueRange = min.toFloat()..max.toFloat(),
-                        steps = ((max.toFloat() - min.toFloat()) / stepIncrement.toFloat()).toInt() - 1,
-                        onValueChange = { secondarySliderValue = convertToV(it) },
-                        onValueChangeFinished = { onPreviewSelectedSecondaryValue(secondarySliderValue) },
-                        colors = SliderDefaults.colors(
-                            thumbColor = MaterialTheme.colorScheme.primary,
-                            activeTrackColor = MaterialTheme.colorScheme.primary,
-                            activeTickColor = Color.Transparent,
-                            inactiveTrackColor = MaterialTheme.colorScheme.onSurface.copy(
-                                alpha = SliderDefaults.colors().inactiveTrackColor.alpha,
-                            ),
-                            inactiveTickColor = Color.Transparent,
-                        ),
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+    Preference(
+        modifier = modifier,
+        icon = icon,
+        iconSpaceReserved = iconSpaceReserved,
+        title = title,
+        summary = summary(primaryPrefValue, secondaryPrefValue),
+        enabledIf = enabledIf,
+        visibleIf = visibleIf,
+        onClick = {
+            primarySliderValue = primaryPrefValue
+            secondarySliderValue = secondaryPrefValue
+            isDialogOpen = true
+        },
+    )
+
+    if (isDialogOpen) {
+        JetPrefAlertDialog(
+            title = title,
+            confirmLabel = dialogStrings.confirmLabel,
+            onConfirm = {
+                primaryPref.set(primarySliderValue)
+                secondaryPref.set(secondarySliderValue)
+                isDialogOpen = false
+            },
+            dismissLabel = dialogStrings.dismissLabel,
+            onDismiss = {
+                isDialogOpen = false
+            },
+            neutralLabel = dialogStrings.neutralLabel,
+            onNeutral = {
+                primaryPref.reset()
+                secondaryPref.reset()
+                isDialogOpen = false
+            },
+        ) {
+            Column {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(primaryLabel)
+                    Text(valueLabel(primarySliderValue))
                 }
+                Slider(
+                    value = primarySliderValue.toFloat(),
+                    valueRange = min.toFloat()..max.toFloat(),
+                    steps = ((max.toFloat() - min.toFloat()) / stepIncrement.toFloat()).toInt() - 1,
+                    onValueChange = { primarySliderValue = convertToV(it) },
+                    onValueChangeFinished = { onPreviewSelectedPrimaryValue(primarySliderValue) },
+                    colors = SliderDefaults.colors(
+                        thumbColor = MaterialTheme.colorScheme.primary,
+                        activeTrackColor = MaterialTheme.colorScheme.primary,
+                        activeTickColor = Color.Transparent,
+                        inactiveTrackColor = MaterialTheme.colorScheme.onSurface.copy(
+                            alpha = SliderDefaults.colors().inactiveTrackColor.alpha,
+                        ),
+                        inactiveTickColor = Color.Transparent,
+                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(secondaryLabel)
+                    Text(valueLabel(secondarySliderValue))
+                }
+                Slider(
+                    value = secondarySliderValue.toFloat(),
+                    valueRange = min.toFloat()..max.toFloat(),
+                    steps = ((max.toFloat() - min.toFloat()) / stepIncrement.toFloat()).toInt() - 1,
+                    onValueChange = { secondarySliderValue = convertToV(it) },
+                    onValueChangeFinished = { onPreviewSelectedSecondaryValue(secondarySliderValue) },
+                    colors = SliderDefaults.colors(
+                        thumbColor = MaterialTheme.colorScheme.primary,
+                        activeTrackColor = MaterialTheme.colorScheme.primary,
+                        activeTickColor = Color.Transparent,
+                        inactiveTrackColor = MaterialTheme.colorScheme.onSurface.copy(
+                            alpha = SliderDefaults.colors().inactiveTrackColor.alpha,
+                        ),
+                        inactiveTickColor = Color.Transparent,
+                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                )
             }
         }
     }
@@ -292,11 +277,11 @@ internal fun <T : PreferenceModel, V> PreferenceUiScope<T>.DialogSliderPreferenc
  */
 @ExperimentalJetPrefDatastoreUi
 @Composable
-fun <T : PreferenceModel> PreferenceUiScope<T>.DialogSliderPreference(
+fun DialogSliderPreference(
     pref: PreferenceData<Int>,
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
-    iconSpaceReserved: Boolean = this.iconSpaceReserved,
+    iconSpaceReserved: Boolean = LocalIconSpaceReserved.current,
     title: String,
     valueLabel: @Composable (Int) -> String = { it.toString() },
     summary: @Composable (Int) -> String = valueLabel,
@@ -355,12 +340,12 @@ fun <T : PreferenceModel> PreferenceUiScope<T>.DialogSliderPreference(
  */
 @ExperimentalJetPrefDatastoreUi
 @Composable
-fun <T : PreferenceModel> PreferenceUiScope<T>.DialogSliderPreference(
+fun DialogSliderPreference(
     primaryPref: PreferenceData<Int>,
     secondaryPref: PreferenceData<Int>,
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
-    iconSpaceReserved: Boolean = this.iconSpaceReserved,
+    iconSpaceReserved: Boolean = LocalIconSpaceReserved.current,
     title: String,
     primaryLabel: String,
     secondaryLabel: String,
@@ -417,11 +402,11 @@ fun <T : PreferenceModel> PreferenceUiScope<T>.DialogSliderPreference(
  */
 @ExperimentalJetPrefDatastoreUi
 @Composable
-fun <T : PreferenceModel> PreferenceUiScope<T>.DialogSliderPreference(
+fun DialogSliderPreference(
     pref: PreferenceData<Long>,
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
-    iconSpaceReserved: Boolean = this.iconSpaceReserved,
+    iconSpaceReserved: Boolean = LocalIconSpaceReserved.current,
     title: String,
     valueLabel: @Composable (Long) -> String = { it.toString() },
     summary: @Composable (Long) -> String = valueLabel,
@@ -480,12 +465,12 @@ fun <T : PreferenceModel> PreferenceUiScope<T>.DialogSliderPreference(
  */
 @ExperimentalJetPrefDatastoreUi
 @Composable
-fun <T : PreferenceModel> PreferenceUiScope<T>.DialogSliderPreference(
+fun DialogSliderPreference(
     primaryPref: PreferenceData<Long>,
     secondaryPref: PreferenceData<Long>,
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
-    iconSpaceReserved: Boolean = this.iconSpaceReserved,
+    iconSpaceReserved: Boolean = LocalIconSpaceReserved.current,
     title: String,
     primaryLabel: String,
     secondaryLabel: String,
@@ -542,11 +527,11 @@ fun <T : PreferenceModel> PreferenceUiScope<T>.DialogSliderPreference(
  */
 @ExperimentalJetPrefDatastoreUi
 @Composable
-fun <T : PreferenceModel> PreferenceUiScope<T>.DialogSliderPreference(
+fun DialogSliderPreference(
     pref: PreferenceData<Double>,
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
-    iconSpaceReserved: Boolean = this.iconSpaceReserved,
+    iconSpaceReserved: Boolean = LocalIconSpaceReserved.current,
     title: String,
     valueLabel: @Composable (Double) -> String = { it.toString() },
     summary: @Composable (Double) -> String = valueLabel,
@@ -599,12 +584,12 @@ fun <T : PreferenceModel> PreferenceUiScope<T>.DialogSliderPreference(
  */
 @ExperimentalJetPrefDatastoreUi
 @Composable
-fun <T : PreferenceModel> PreferenceUiScope<T>.DialogSliderPreference(
+fun DialogSliderPreference(
     primaryPref: PreferenceData<Double>,
     secondaryPref: PreferenceData<Double>,
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
-    iconSpaceReserved: Boolean = this.iconSpaceReserved,
+    iconSpaceReserved: Boolean = LocalIconSpaceReserved.current,
     title: String,
     primaryLabel: String,
     secondaryLabel: String,
@@ -655,11 +640,11 @@ fun <T : PreferenceModel> PreferenceUiScope<T>.DialogSliderPreference(
  */
 @ExperimentalJetPrefDatastoreUi
 @Composable
-fun <T : PreferenceModel> PreferenceUiScope<T>.DialogSliderPreference(
+fun DialogSliderPreference(
     pref: PreferenceData<Float>,
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
-    iconSpaceReserved: Boolean = this.iconSpaceReserved,
+    iconSpaceReserved: Boolean = LocalIconSpaceReserved.current,
     title: String,
     valueLabel: @Composable (Float) -> String = { it.toString() },
     summary: @Composable (Float) -> String = valueLabel,
@@ -712,12 +697,12 @@ fun <T : PreferenceModel> PreferenceUiScope<T>.DialogSliderPreference(
  */
 @ExperimentalJetPrefDatastoreUi
 @Composable
-fun <T : PreferenceModel> PreferenceUiScope<T>.DialogSliderPreference(
+fun DialogSliderPreference(
     primaryPref: PreferenceData<Float>,
     secondaryPref: PreferenceData<Float>,
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
-    iconSpaceReserved: Boolean = this.iconSpaceReserved,
+    iconSpaceReserved: Boolean = LocalIconSpaceReserved.current,
     title: String,
     primaryLabel: String,
     secondaryLabel: String,

--- a/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/DialogSliderPreference.kt
+++ b/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/DialogSliderPreference.kt
@@ -71,7 +71,7 @@ internal fun <T : PreferenceModel, V> PreferenceUiScope<T>.DialogSliderPreferenc
 
     val prefValue by pref.observeAsState()
     var sliderValue by remember { mutableFloatStateOf(0.0f) }
-    val isDialogOpen = remember { mutableStateOf(false) }
+    var isDialogOpen by remember { mutableStateOf(false) }
 
     val evalScope = PreferenceDataEvaluatorScope.instance()
     if (this.visibleIf(evalScope) && visibleIf(evalScope)) {
@@ -83,7 +83,7 @@ internal fun <T : PreferenceModel, V> PreferenceUiScope<T>.DialogSliderPreferenc
                     role = Role.Button,
                     onClick = {
                         sliderValue = prefValue.toFloat()
-                        isDialogOpen.value = true
+                        isDialogOpen = true
                     }
                 ),
             icon = maybeJetIcon(imageVector = icon, iconSpaceReserved = iconSpaceReserved),
@@ -91,21 +91,23 @@ internal fun <T : PreferenceModel, V> PreferenceUiScope<T>.DialogSliderPreferenc
             secondaryText = summary(prefValue),
             enabled = isEnabled,
         )
-        if (isDialogOpen.value) {
+        if (isDialogOpen) {
             JetPrefAlertDialog(
                 title = title,
                 confirmLabel = dialogStrings.confirmLabel,
                 onConfirm = {
                     pref.set(convertToV(sliderValue))
-                    isDialogOpen.value = false
+                    isDialogOpen = false
                 },
                 dismissLabel = dialogStrings.dismissLabel,
-                onDismiss = { isDialogOpen.value = false },
+                onDismiss = {
+                    isDialogOpen = false
+                },
                 neutralLabel = dialogStrings.neutralLabel,
                 onNeutral = {
                     pref.reset()
-                    isDialogOpen.value = false
-                }
+                    isDialogOpen = false
+                },
             ) {
                 Column {
                     Text(
@@ -165,7 +167,7 @@ internal fun <T : PreferenceModel, V> PreferenceUiScope<T>.DialogSliderPreferenc
     val secondaryPrefValue by secondaryPref.observeAsState()
     var primarySliderValue by remember { mutableStateOf(convertToV(0.0f)) }
     var secondarySliderValue by remember { mutableStateOf(convertToV(0.0f)) }
-    val isDialogOpen = remember { mutableStateOf(false) }
+    var isDialogOpen by remember { mutableStateOf(false) }
 
     val evalScope = PreferenceDataEvaluatorScope.instance()
     if (this.visibleIf(evalScope) && visibleIf(evalScope)) {
@@ -178,7 +180,7 @@ internal fun <T : PreferenceModel, V> PreferenceUiScope<T>.DialogSliderPreferenc
                     onClick = {
                         primarySliderValue = primaryPrefValue
                         secondarySliderValue = secondaryPrefValue
-                        isDialogOpen.value = true
+                        isDialogOpen = true
                     }
                 ),
             icon = maybeJetIcon(imageVector = icon, iconSpaceReserved = iconSpaceReserved),
@@ -186,23 +188,25 @@ internal fun <T : PreferenceModel, V> PreferenceUiScope<T>.DialogSliderPreferenc
             secondaryText = summary(primaryPrefValue, secondaryPrefValue),
             enabled = isEnabled,
         )
-        if (isDialogOpen.value) {
+        if (isDialogOpen) {
             JetPrefAlertDialog(
                 title = title,
                 confirmLabel = dialogStrings.confirmLabel,
                 onConfirm = {
                     primaryPref.set(primarySliderValue)
                     secondaryPref.set(secondarySliderValue)
-                    isDialogOpen.value = false
+                    isDialogOpen = false
                 },
                 dismissLabel = dialogStrings.dismissLabel,
-                onDismiss = { isDialogOpen.value = false },
+                onDismiss = {
+                    isDialogOpen = false
+                },
                 neutralLabel = dialogStrings.neutralLabel,
                 onNeutral = {
                     primaryPref.reset()
                     secondaryPref.reset()
-                    isDialogOpen.value = false
-                }
+                    isDialogOpen = false
+                },
             ) {
                 Column {
                     Row(

--- a/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/ListPreference.kt
+++ b/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/ListPreference.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -52,7 +53,9 @@ import dev.patrickgold.jetpref.datastore.model.PreferenceDataEvaluatorScope
 import dev.patrickgold.jetpref.datastore.model.PreferenceModel
 import dev.patrickgold.jetpref.datastore.model.observeAsState
 import dev.patrickgold.jetpref.material.ui.JetPrefAlertDialog
+import dev.patrickgold.jetpref.material.ui.JetPrefAlertDialogDefaults
 import dev.patrickgold.jetpref.material.ui.JetPrefListItem
+import dev.patrickgold.jetpref.material.ui.copy
 
 /**
  * Data class specifying a single list preference entry.
@@ -71,6 +74,8 @@ import dev.patrickgold.jetpref.material.ui.JetPrefListItem
  * @property showDescriptionOnlyIfSelected True if the description should be shown only if the
  *  list entry is selected, false if it should be shown for all entries. This flag does nothing
  *  if the description is a blank string and not showing for this entry.
+ *
+ * @since 0.1.0
  */
 data class ListPreferenceEntry<V : Any>(
     val key: V,
@@ -85,10 +90,14 @@ data class ListPreferenceEntry<V : Any>(
  * Builder scope for creating a list of list preference entries.
  *
  * @param V The type of the entry keys.
+ *
+ * @since 0.1.0
  */
 interface ListPreferenceEntriesScope<V : Any> {
     /**
      * Creates an entry without a description.
+     *
+     * @since 0.1.0
      */
     fun entry(
         key: V,
@@ -97,6 +106,8 @@ interface ListPreferenceEntriesScope<V : Any> {
 
     /**
      * Creates an entry with a label + description.
+     *
+     * @since 0.1.0
      */
     fun entry(
         key: V,
@@ -107,6 +118,8 @@ interface ListPreferenceEntriesScope<V : Any> {
 
     /**
      * Creates an entry with a label + description and custom description composer.
+     *
+     * @since 0.1.0
      */
     fun entry(
         key: V,
@@ -118,6 +131,8 @@ interface ListPreferenceEntriesScope<V : Any> {
 
     /**
      * Creates an entry with a label + description and custom composers for both.
+     *
+     * @since 0.1.0
      */
     fun entry(
         key: V,
@@ -181,6 +196,8 @@ private class ListPreferenceEntriesScopeImpl<V : Any> : ListPreferenceEntriesSco
  * @param scope THe builder scope for the entries list.
  *
  * @return A list of [ListPreferenceEntry] items.
+ *
+ * @since 0.1.0
  */
 @Composable
 fun <V : Any> listPrefEntries(
@@ -191,6 +208,29 @@ fun <V : Any> listPrefEntries(
     return builder.build()
 }
 
+/**
+ * Material list preference which allows the user to select a single entry from a list of entries. Optionally, a switch
+ * preference can be provided to enable or disable the list preference's entries.
+ *
+ * @param listPref The [PreferenceData] for the list preference.
+ * @param switchPref The [PreferenceData] for the switch preference. If null, no switch will be shown.
+ * @param modifier Modifier to be applied to the underlying list item.
+ * @param icon The [ImageVector] of the list entry.
+ * @param iconSpaceReserved Whether the icon space should be reserved even if no icon is provided.
+ * @param title The title of this preference, shown as the list item primary text (max 1 line).
+ * @param summarySwitchDisabled The summary of this preference if the switch is disabled. If this is
+ *  specified it will override the auto-generated summary. Shown as the list item secondary text (max 2 lines).
+ * @param dialogStrings The dialog strings to use for this dialog. Defaults to the current dialog prefs set.
+ * @param enabledIf Evaluator scope which allows to dynamically decide if this preference should be enabled (true) or
+ *  disabled (false).
+ * @param visibleIf Evaluator scope which allows to dynamically decide if this preference should be visible (true) or
+ *  hidden (false).
+ * @param entries The list of list preference entries.
+ *
+ * @since 0.1.0
+ *
+ * @see listPrefEntries
+ */
 @SuppressLint("ModifierParameter")
 @Composable
 fun <T : PreferenceModel, V : Any> PreferenceUiScope<T>.ListPreference(
@@ -210,7 +250,7 @@ fun <T : PreferenceModel, V : Any> PreferenceUiScope<T>.ListPreference(
     val switchPrefValue = switchPref?.observeAsState() // can't use delegate because nullable
     val (tmpListPrefValue, setTmpListPrefValue) = remember { mutableStateOf(listPref.get()) }
     val (tmpSwitchPrefValue, setTmpSwitchPrefValue) = remember { mutableStateOf(false) }
-    val isDialogOpen = remember { mutableStateOf(false) }
+    var isDialogOpen by remember { mutableStateOf(false) }
 
     val evalScope = PreferenceDataEvaluatorScope.instance()
     if (this.visibleIf(evalScope) && visibleIf(evalScope)) {
@@ -225,7 +265,7 @@ fun <T : PreferenceModel, V : Any> PreferenceUiScope<T>.ListPreference(
                         if (switchPrefValue != null) {
                             setTmpSwitchPrefValue(switchPrefValue.value)
                         }
-                        isDialogOpen.value = true
+                        isDialogOpen = true
                     }
                 ),
             icon = maybeJetIcon(imageVector = icon, iconSpaceReserved = iconSpaceReserved),
@@ -268,22 +308,24 @@ fun <T : PreferenceModel, V : Any> PreferenceUiScope<T>.ListPreference(
             },
             enabled = isEnabled,
         )
-        if (isDialogOpen.value) {
+        if (isDialogOpen) {
             JetPrefAlertDialog(
                 title = title,
                 confirmLabel = dialogStrings.confirmLabel,
                 onConfirm = {
                     listPref.set(tmpListPrefValue)
                     switchPref?.set(tmpSwitchPrefValue)
-                    isDialogOpen.value = false
+                    isDialogOpen = false
                 },
                 dismissLabel = dialogStrings.dismissLabel,
-                onDismiss = { isDialogOpen.value = false },
+                onDismiss = {
+                    isDialogOpen = false
+                },
                 neutralLabel = dialogStrings.neutralLabel,
                 onNeutral = {
                     listPref.reset()
                     switchPref?.reset()
-                    isDialogOpen.value = false
+                    isDialogOpen = false
                 },
                 trailingIconTitle = {
                     if (switchPrefValue != null) {
@@ -293,6 +335,13 @@ fun <T : PreferenceModel, V : Any> PreferenceUiScope<T>.ListPreference(
                             onCheckedChange = { setTmpSwitchPrefValue(it) },
                             enabled = true,
                         )
+                    }
+                },
+                titlePadding = remember(switchPrefValue) {
+                    if (switchPrefValue != null) {
+                        JetPrefAlertDialogDefaults.TitlePadding.copy(top = 16.dp)
+                    } else {
+                        JetPrefAlertDialogDefaults.TitlePadding
                     }
                 },
                 contentPadding = PaddingValues(horizontal = 8.dp),
@@ -329,7 +378,9 @@ fun <T : PreferenceModel, V : Any> PreferenceUiScope<T>.ListPreference(
                                 modifier = Modifier.padding(end = 12.dp),
                             )
                             Column(
-                                modifier = Modifier.fillMaxWidth()
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .align(Alignment.CenterVertically),
                             ) {
                                 entry.labelComposer(entry.label)
                                 if (entry.showDescriptionOnlyIfSelected) {

--- a/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/SwitchPreference.kt
+++ b/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/SwitchPreference.kt
@@ -38,17 +38,18 @@ import dev.patrickgold.jetpref.material.ui.JetPrefListItem
  * @param pref The boolean preference data entry from the datastore.
  * @param modifier Modifier to be applied to the underlying list item.
  * @param icon The [ImageVector] of the list entry.
+ * @param iconSpaceReserved Whether the icon space should be reserved even if no icon is provided.
  * @param title The title of this preference, shown as the list item primary text (max 1 line).
  * @param summary The summary of this preference, shown as the list item secondary text (max 2 lines).
  * @param summaryOn The summary of this preference if the state is `true`. If this is specified it will override
- *     provided [summary]. Shown as the list item secondary text (max 2 lines).
+ *  provided [summary]. Shown as the list item secondary text (max 2 lines).
  * @param summaryOff The summary of this preference if the state is `false`. If this is specified it will override
- *     provided [summary]. Shown as the list item secondary text (max 2 lines).
+ *  provided [summary]. Shown as the list item secondary text (max 2 lines).
  * @param enabledIf Evaluator scope which allows to dynamically decide if this preference should be enabled (true) or
- *     disabled (false).
+ *  disabled (false).
  * @param visibleIf Evaluator scope which allows to dynamically decide if this preference should be visible (true) or
- *     hidden (false).
- * @see maybeJetIcon
+ *  hidden (false).
+ *
  * @since 0.1.0
  */
 @Composable
@@ -75,7 +76,7 @@ fun <T : PreferenceModel> PreferenceUiScope<T>.SwitchPreference(
                     value = prefValue,
                     enabled = isEnabled,
                     role = Role.Switch,
-                    onValueChange = { pref.set(it) }
+                    onValueChange = { pref.set(it) },
                 ),
             icon = maybeJetIcon(imageVector = icon, iconSpaceReserved = iconSpaceReserved),
             text = title,
@@ -90,7 +91,7 @@ fun <T : PreferenceModel> PreferenceUiScope<T>.SwitchPreference(
                     modifier = Modifier.size(LocalViewConfiguration.current.minimumTouchTargetSize),
                     checked = prefValue,
                     onCheckedChange = null,
-                    enabled = isEnabled
+                    enabled = isEnabled,
                 )
             },
             enabled = isEnabled,

--- a/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/SwitchPreference.kt
+++ b/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/SwitchPreference.kt
@@ -27,10 +27,7 @@ import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.semantics.Role
 import dev.patrickgold.jetpref.datastore.model.PreferenceData
 import dev.patrickgold.jetpref.datastore.model.PreferenceDataEvaluator
-import dev.patrickgold.jetpref.datastore.model.PreferenceDataEvaluatorScope
-import dev.patrickgold.jetpref.datastore.model.PreferenceModel
 import dev.patrickgold.jetpref.datastore.model.observeAsState
-import dev.patrickgold.jetpref.material.ui.JetPrefListItem
 
 /**
  * Material switch preference which provides a list item with a trailing switch.
@@ -53,11 +50,11 @@ import dev.patrickgold.jetpref.material.ui.JetPrefListItem
  * @since 0.1.0
  */
 @Composable
-fun <T : PreferenceModel> PreferenceUiScope<T>.SwitchPreference(
+fun SwitchPreference(
     pref: PreferenceData<Boolean>,
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
-    iconSpaceReserved: Boolean = this.iconSpaceReserved,
+    iconSpaceReserved: Boolean = LocalIconSpaceReserved.current,
     title: String,
     summary: String? = null,
     summaryOn: String? = null,
@@ -67,34 +64,34 @@ fun <T : PreferenceModel> PreferenceUiScope<T>.SwitchPreference(
 ) {
     val prefValue by pref.observeAsState()
 
-    val evalScope = PreferenceDataEvaluatorScope.instance()
-    if (this.visibleIf(evalScope) && visibleIf(evalScope)) {
-        val isEnabled = this.enabledIf(evalScope) && enabledIf(evalScope)
-        JetPrefListItem(
-            modifier = modifier
-                .toggleable(
-                    value = prefValue,
-                    enabled = isEnabled,
-                    role = Role.Switch,
-                    onValueChange = { pref.set(it) },
-                ),
-            icon = maybeJetIcon(imageVector = icon, iconSpaceReserved = iconSpaceReserved),
-            text = title,
-            secondaryText = when {
-                prefValue && summaryOn != null -> summaryOn
-                !prefValue && summaryOff != null -> summaryOff
-                summary != null -> summary
-                else -> null
-            },
-            trailing = {
-                Switch(
-                    modifier = Modifier.size(LocalViewConfiguration.current.minimumTouchTargetSize),
-                    checked = prefValue,
-                    onCheckedChange = null,
-                    enabled = isEnabled,
-                )
-            },
-            enabled = isEnabled,
-        )
-    }
+    Preference(
+        modifier = modifier,
+        eventModifier = {
+            Modifier.toggleable(
+                value = prefValue,
+                enabled = LocalIsPrefEnabled.current,
+                role = Role.Switch,
+                onValueChange = { pref.set(it) },
+            )
+        },
+        icon = icon,
+        iconSpaceReserved = iconSpaceReserved,
+        title = title,
+        summary = when {
+            prefValue && summaryOn != null -> summaryOn
+            !prefValue && summaryOff != null -> summaryOff
+            summary != null -> summary
+            else -> null
+        },
+        trailing = {
+            Switch(
+                modifier = Modifier.size(LocalViewConfiguration.current.minimumTouchTargetSize),
+                checked = prefValue,
+                onCheckedChange = null,
+                enabled = LocalIsPrefEnabled.current,
+            )
+        },
+        enabledIf = enabledIf,
+        visibleIf = visibleIf,
+    )
 }

--- a/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/TextFieldPreference.kt
+++ b/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/TextFieldPreference.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import dev.patrickgold.jetpref.datastore.model.PreferenceData
 import dev.patrickgold.jetpref.datastore.model.PreferenceDataEvaluator
-import dev.patrickgold.jetpref.datastore.model.PreferenceModel
 import dev.patrickgold.jetpref.datastore.model.observeAsState
 import dev.patrickgold.jetpref.material.ui.JetPrefAlertDialog
 import dev.patrickgold.jetpref.material.ui.whenNotNullOrBlank
@@ -57,11 +56,11 @@ import dev.patrickgold.jetpref.material.ui.whenNotNullOrBlank
  * @since 0.2.0
  */
 @Composable
-fun <T : PreferenceModel> PreferenceUiScope<T>.TextFieldPreference(
+fun TextFieldPreference(
     pref: PreferenceData<String>,
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
-    iconSpaceReserved: Boolean = this.iconSpaceReserved,
+    iconSpaceReserved: Boolean = LocalIconSpaceReserved.current,
     title: String,
     summaryIfBlank: String? = null,
     summaryIfEmpty: String? = null,

--- a/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/TextFieldPreference.kt
+++ b/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/TextFieldPreference.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2024 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.jetpref.datastore.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import dev.patrickgold.jetpref.datastore.model.PreferenceData
+import dev.patrickgold.jetpref.datastore.model.PreferenceDataEvaluator
+import dev.patrickgold.jetpref.datastore.model.PreferenceModel
+import dev.patrickgold.jetpref.datastore.model.observeAsState
+import dev.patrickgold.jetpref.material.ui.JetPrefAlertDialog
+import dev.patrickgold.jetpref.material.ui.whenNotNullOrBlank
+
+/**
+ * Material text field preference which provides a dialog with a text field.
+ *
+ * @param pref The string preference data entry from the datastore.
+ * @param modifier Modifier to be applied to the underlying list item.
+ * @param icon The [ImageVector] of the list entry.
+ * @param iconSpaceReserved Whether the icon space should be reserved even if no icon is provided.
+ * @param title The title of this preference, shown as the list item primary text (max 1 line).
+ * @param summaryIfBlank The summary of this preference if the state is blank.
+ * @param summaryIfEmpty The summary of this preference if the state is empty.
+ * @param summary The summary function of this preference, shown as the list item secondary text (max 2 lines). If
+ *  this is specified it will override provided [summaryIfBlank] and [summaryIfEmpty].
+ * @param dialogStrings The dialog strings to use for this dialog. Defaults to the current dialog prefs set.
+ * @param transformValue The transformation function to transform the entered value before saving/validating it.
+ * @param validateValue The validation function to check if the entered value is valid (after transformation). To
+ *  indicate an invalid value, throw an exception.
+ * @param enabledIf Evaluator scope which allows to dynamically decide if this preference should be enabled (true) or
+ *  disabled (false).
+ * @param visibleIf Evaluator scope which allows to dynamically decide if this preference should be visible (true) or
+ *  hidden (false).
+ *
+ * @since 0.2.0
+ */
+@Composable
+fun <T : PreferenceModel> PreferenceUiScope<T>.TextFieldPreference(
+    pref: PreferenceData<String>,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    iconSpaceReserved: Boolean = this.iconSpaceReserved,
+    title: String,
+    summaryIfBlank: String? = null,
+    summaryIfEmpty: String? = null,
+    summary: (String) -> String? = {
+        when {
+            it.isEmpty() -> summaryIfEmpty ?: it
+            it.isBlank() -> summaryIfBlank ?: it
+            else -> it
+        }
+    },
+    dialogStrings: DialogPrefStrings = LocalDefaultDialogPrefStrings.current,
+    transformValue: (String) -> String = { it },
+    validateValue: (String) -> Unit = { },
+    enabledIf: PreferenceDataEvaluator = { true },
+    visibleIf: PreferenceDataEvaluator = { true },
+) {
+    val prefValue by pref.observeAsState()
+    var localPrefValue by remember { mutableStateOf("") }
+    var isDialogOpen by remember { mutableStateOf(false) }
+
+    Preference(
+        modifier = modifier,
+        icon = icon,
+        iconSpaceReserved = iconSpaceReserved,
+        title = title,
+        summary = summary(prefValue),
+        enabledIf = enabledIf,
+        visibleIf = visibleIf,
+        onClick = {
+            localPrefValue = pref.get()
+            isDialogOpen = true
+        },
+    )
+
+    if (isDialogOpen) {
+        val validationResult = remember(localPrefValue) {
+            runCatching {
+                validateValue(transformValue(localPrefValue))
+            }
+        }
+        JetPrefAlertDialog(
+            title = title,
+            confirmLabel = dialogStrings.confirmLabel,
+            confirmEnabled = validationResult.isSuccess,
+            onConfirm = {
+                pref.set(transformValue(localPrefValue))
+                isDialogOpen = false
+            },
+            dismissLabel = dialogStrings.dismissLabel,
+            onDismiss = {
+                isDialogOpen = false
+            },
+            neutralLabel = dialogStrings.neutralLabel,
+            onNeutral = {
+                pref.reset()
+                isDialogOpen = false
+            },
+        ) {
+            Column {
+                val message = remember(validationResult) {
+                    validationResult.exceptionOrNull()?.let { error ->
+                        error.localizedMessage ?: error.message
+                    }
+                }
+                OutlinedTextField(
+                    value = localPrefValue,
+                    onValueChange = { localPrefValue = it },
+                    isError = validationResult.isFailure,
+                    supportingText = whenNotNullOrBlank(message) { Text(it) },
+                )
+            }
+        }
+    }
+}

--- a/example/src/main/kotlin/dev/patrickgold/jetpref/example/AppPrefs.kt
+++ b/example/src/main/kotlin/dev/patrickgold/jetpref/example/AppPrefs.kt
@@ -68,6 +68,14 @@ class AppPrefs : PreferenceModel("example-app-preferences") {
             key = "test__show_title",
             default = true,
         )
+        val description = string(
+            key = "test__description",
+            default = "",
+        )
+        val itemKey = string(
+            key = "test__item_key",
+            default = "abc_item_key",
+        )
 
         val longListPref = string(
             key = "test__long_list",

--- a/example/src/main/kotlin/dev/patrickgold/jetpref/example/MainActivity.kt
+++ b/example/src/main/kotlin/dev/patrickgold/jetpref/example/MainActivity.kt
@@ -58,9 +58,9 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun AppContent(navController: NavHostController) {
     ProvideDefaultDialogPrefStrings(
-        confirmLabel = "Confirm",
-        dismissLabel = "Dismiss",
-        neutralLabel = "Def. value",
+        confirmLabel = "OK",
+        dismissLabel = "Cancel",
+        neutralLabel = "Default",
     ) {
         Column {
             TopAppBar(

--- a/example/src/main/kotlin/dev/patrickgold/jetpref/example/ui/settings/HomeScreen.kt
+++ b/example/src/main/kotlin/dev/patrickgold/jetpref/example/ui/settings/HomeScreen.kt
@@ -177,13 +177,13 @@ fun HomeScreen() = ScrollablePreferenceLayout(examplePreferenceModel()) {
         },
     )
     TextFieldPreference(
-        pref = prefs.example.description,
+        prefs.example.description,
         title = "Description",
         summaryIfBlank = "(blank)",
         summaryIfEmpty = "(empty)",
     )
     TextFieldPreference(
-        pref = prefs.example.itemKey,
+        prefs.example.itemKey,
         title = "Item key",
         validateValue = {
             "[a-z0-9_]+".toRegex().matches(it) || error("Invalid key")

--- a/example/src/main/kotlin/dev/patrickgold/jetpref/example/ui/settings/HomeScreen.kt
+++ b/example/src/main/kotlin/dev/patrickgold/jetpref/example/ui/settings/HomeScreen.kt
@@ -29,6 +29,7 @@ import dev.patrickgold.jetpref.datastore.ui.Preference
 import dev.patrickgold.jetpref.datastore.ui.PreferenceGroup
 import dev.patrickgold.jetpref.datastore.ui.ScrollablePreferenceLayout
 import dev.patrickgold.jetpref.datastore.ui.SwitchPreference
+import dev.patrickgold.jetpref.datastore.ui.TextFieldPreference
 import dev.patrickgold.jetpref.datastore.ui.listPrefEntries
 import dev.patrickgold.jetpref.datastore.ui.vectorResource
 import dev.patrickgold.jetpref.example.LocalNavController
@@ -175,9 +176,23 @@ fun HomeScreen() = ScrollablePreferenceLayout(examplePreferenceModel()) {
             )
         },
     )
+    TextFieldPreference(
+        pref = prefs.example.description,
+        title = "Description",
+        summaryIfBlank = "(blank)",
+        summaryIfEmpty = "(empty)",
+    )
+    TextFieldPreference(
+        pref = prefs.example.itemKey,
+        title = "Item key",
+        validateValue = {
+            "[a-z0-9_]+".toRegex().matches(it) || error("Invalid key")
+        },
+        transformValue = { it.trim() },
+    )
     ListPreference(
         listPref = prefs.example.longListPref,
-        title = "Test the scoll behaviour",
+        title = "Test the scroll behaviour",
         entries = listPrefEntries {
             entry(
                 "str1",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
 # Main
-android-gradle-plugin = "8.2.2"
-androidx-activity = "1.8.2"
-androidx-compose = "1.6.1"
-androidx-compose-compiler = "1.5.9"
-androidx-compose-material3 = "1.2.0"
-androidx-core = "1.12.0"
-androidx-lifecycle = "2.7.0"
-androidx-material-icons = "1.6.4"
-androidx-navigation = "2.7.7"
-kotlin = "1.9.22"
-kotlinx-coroutines = "1.7.3"
-vanniktech-maven-publish = "0.28.0"
+android-gradle-plugin = "8.5.2"
+androidx-activity = "1.9.2"
+androidx-compose = "1.7.0"
+androidx-compose-compiler = "1.5.15"
+androidx-compose-material3 = "1.3.0"
+androidx-core = "1.13.1"
+androidx-lifecycle = "2.8.5"
+androidx-material-icons = "1.7.0"
+androidx-navigation = "2.8.0"
+kotlin = "1.9.25"
+kotlinx-coroutines = "1.8.1"
+vanniktech-maven-publish = "0.29.0"
 
 # Testing
 kotest = "5.4.0"
@@ -19,8 +19,6 @@ kotest = "5.4.0"
 [libraries]
 # Main
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
-androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }
-androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidx-compose-material3" }
 androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata", version.ref = "androidx-compose" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidx-compose" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=38f66cd6eef217b4c35855bb11ea4e9fbc53594ccccb5fb82dfd317ef8c2c5a3
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionSha256Sum=544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2009b961d
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/Common.kt
+++ b/material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/Common.kt
@@ -44,6 +44,28 @@ inline fun whenNotNullOrBlank(
 }
 
 /**
+ * Composable function to only execute the given composable function if the given object is not null.
+ * This is useful for conditional composable functions.
+ *
+ * @param obj The object to check for null.
+ * @param composer The composable function to execute if the object is not null.
+ *
+ * @return The composable function or null.
+ *
+ * @since 0.2.0
+ */
+@Composable
+inline fun <T : Any> whenNotNull(
+    obj: T?,
+    crossinline composer: @Composable (obj: T) -> Unit,
+): @Composable (() -> Unit)? {
+    return when {
+        obj != null -> ({ composer(obj) })
+        else -> null
+    }
+}
+
+/**
  * Copies the padding values and applies the given values if they are not null.
  *
  * @param start The start padding value to apply if not null.

--- a/material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/Common.kt
+++ b/material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/Common.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Patrick Goldinger
+ * Copyright 2021-2024 Patrick Goldinger
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,10 @@
 
 package dev.patrickgold.jetpref.material.ui
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 
 @Composable
 internal inline fun whenNotNullOrBlank(
@@ -27,4 +30,34 @@ internal inline fun whenNotNullOrBlank(
         !string.isNullOrBlank() -> ({ composer(string) })
         else -> null
     }
+}
+
+/**
+ * Copies the padding values and applies the given values if they are not null.
+ *
+ * @param start The start padding value to apply if not null.
+ * @param top The top padding value to apply if not null.
+ * @param end The end padding value to apply if not null.
+ * @param bottom The bottom padding value to apply if not null.
+ *
+ * @return The new [PaddingValues] with the applied padding values.
+ *
+ * @since 0.2.0
+ */
+fun PaddingValues.copy(
+    start: Dp? = null,
+    top: Dp? = null,
+    end: Dp? = null,
+    bottom: Dp? = null,
+): PaddingValues {
+    require(this::class != PaddingValues::Absolute::class) {
+        "Cannot copy absolute padding values with this helper."
+    }
+    // We can force LTR here because we are only copying and not in the layout process
+    return PaddingValues(
+        start = start ?: this.calculateLeftPadding(LayoutDirection.Ltr),
+        top = top ?: this.calculateTopPadding(),
+        end = end ?: this.calculateRightPadding(LayoutDirection.Ltr),
+        bottom = bottom ?: this.calculateBottomPadding(),
+    )
 }

--- a/material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/Common.kt
+++ b/material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/Common.kt
@@ -21,8 +21,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 
+/**
+ * Composable function to only execute the given composable function if the given string is not null or blank.
+ * This is useful for conditional composable functions.
+ *
+ * @param string The string to check for null or blank.
+ * @param composer The composable function to execute if the string is not null or blank.
+ *
+ * @return The composable function or null.
+ *
+ * @since 0.2.0
+ */
 @Composable
-internal inline fun whenNotNullOrBlank(
+inline fun whenNotNullOrBlank(
     string: String?,
     crossinline composer: @Composable (text: String) -> Unit,
 ): @Composable (() -> Unit)? {

--- a/material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/JetPrefAlertDialog.kt
+++ b/material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/JetPrefAlertDialog.kt
@@ -55,16 +55,19 @@ import androidx.compose.ui.window.DialogProperties
  *  visibility of the confirm button. Passing null or a blank string will hide the button,
  *  any other string will show it.
  * @param confirmColors The colors to apply to the confirm button, if it is visible.
+ * @param confirmEnabled Whether the confirm button should be enabled, if it is visible.
  * @param onConfirm Action to execute when the confirm button is pressed.
  * @param dismissLabel The label of the dismiss button of this dialog. Used to control the
  *  visibility of the dismiss button. Passing null or a blank string will hide the button,
  *  any other string will show it.
  * @param dismissColors The colors to apply to the dismiss button, if it is visible.
+ * @param dismissEnabled Whether the dismiss button should be enabled, if it is visible.
  * @param onDismiss Action to execute when the dismiss button is pressed.
  * @param neutralLabel The label of the neutral button of this dialog. Used to control the
  *  visibility of the neutral button. Passing null or a blank string will hide the button,
  *  any other string will show it.
  * @param neutralColors The colors to apply to the neutral button, if it is visible.
+ * @param neutralEnabled Whether the neutral button should be enabled, if it is visible.
  * @param onNeutral Action to execute when the neutral button is pressed.
  * @param allowOutsideDismissal Specify if a user can dismiss the Dialog by clicking outside
  *  or pressing the back button.
@@ -80,6 +83,9 @@ import androidx.compose.ui.window.DialogProperties
  * @param titleContentColor The color for the title of this dialog.
  * @param textContentColor The content color of this dialog.
  * @param properties Dialog properties for further customization of this dialog's behavior.
+ * @param titlePadding The padding to apply to the title of this dialog.
+ * @param contentPadding The padding to apply to the content of this dialog.
+ * @param buttonsPadding The padding to apply to the buttons of this dialog.
  * @param content The content to be displayed inside the dialog.
  *
  * @since 0.1.0
@@ -93,14 +99,16 @@ fun JetPrefAlertDialog(
     modifier: Modifier = Modifier,
     confirmLabel: String? = null,
     confirmColors: ButtonColors = ButtonDefaults.textButtonColors(),
+    confirmEnabled: Boolean = true,
     onConfirm: () -> Unit = { },
     dismissLabel: String? = null,
     dismissColors: ButtonColors = ButtonDefaults.textButtonColors(),
+    dismissEnabled: Boolean = true,
     onDismiss: () -> Unit = { },
     neutralLabel: String? = null,
     neutralColors: ButtonColors = ButtonDefaults.textButtonColors(),
+    neutralEnabled: Boolean = true,
     onNeutral: () -> Unit = { },
-    contentPadding: PaddingValues = JetPrefAlertDialogDefaults.ContentPadding,
     allowOutsideDismissal: Boolean = true,
     onOutsideDismissal: () -> Unit = onDismiss,
     trailingIconTitle: @Composable () -> Unit = { },
@@ -110,35 +118,39 @@ fun JetPrefAlertDialog(
     titleContentColor: Color = AlertDialogDefaults.titleContentColor,
     textContentColor: Color = AlertDialogDefaults.textContentColor,
     properties: DialogProperties = DialogProperties(usePlatformDefaultWidth = true),
+    titlePadding: PaddingValues = JetPrefAlertDialogDefaults.TitlePadding,
+    contentPadding: PaddingValues = JetPrefAlertDialogDefaults.ContentPadding,
+    buttonsPadding: PaddingValues = JetPrefAlertDialogDefaults.ButtonsPadding,
     content: @Composable () -> Unit,
 ) {
     Dialog(
         onDismissRequest = { if (allowOutsideDismissal) onOutsideDismissal() },
-        properties = properties
+        properties = properties,
     ) {
         Card(
             modifier = modifier
-                .padding(vertical = 16.dp, horizontal = 16.dp)
-                .widthIn(max = JetPrefAlertDialogDefaults.MaxDialogWidth),
+                .padding(all = 16.dp)
+                .widthIn(
+                    min = JetPrefAlertDialogDefaults.MinDialogWidth,
+                    max = JetPrefAlertDialogDefaults.MaxDialogWidth,
+                ),
             shape = shape,
             colors = CardDefaults.cardColors(
                 containerColor = containerColor,
-                contentColor = textContentColor
-            )
+                contentColor = textContentColor,
+            ),
         ) {
             Column {
                 Row(
-                    modifier = Modifier
-                        .padding(top = 16.dp, bottom = 8.dp)
-                        .padding(horizontal = 16.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    modifier = Modifier.padding(titlePadding),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
                         modifier = Modifier.weight(1.0f),
                         text = title,
-                        textAlign = TextAlign.Center,
+                        textAlign = TextAlign.Start,
                         color = titleContentColor,
-                        style = MaterialTheme.typography.titleMedium,
+                        style = MaterialTheme.typography.headlineSmall,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
@@ -153,12 +165,13 @@ fun JetPrefAlertDialog(
                 ) {
                     content()
                 }
-                Row(modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp)) {
+                Row(Modifier.padding(buttonsPadding)) {
                     if (!neutralLabel.isNullOrBlank()) {
                         TextButton(
-                            onClick = onNeutral,
                             modifier = Modifier.padding(end = 8.dp),
                             colors = neutralColors,
+                            enabled = neutralEnabled,
+                            onClick = onNeutral,
                         ) {
                             Text(neutralLabel)
                         }
@@ -166,17 +179,19 @@ fun JetPrefAlertDialog(
                     Spacer(modifier = Modifier.weight(1.0f))
                     if (!dismissLabel.isNullOrBlank()) {
                         TextButton(
-                            onClick = onDismiss,
                             modifier = Modifier.padding(end = 8.dp),
                             colors = dismissColors,
+                            enabled = dismissEnabled,
+                            onClick = onDismiss,
                         ) {
                             Text(dismissLabel)
                         }
                     }
                     if (!confirmLabel.isNullOrBlank()) {
                         TextButton(
-                            onClick = onConfirm,
                             colors = confirmColors,
+                            enabled = confirmEnabled,
+                            onClick = onConfirm,
                         ) {
                             Text(confirmLabel)
                         }
@@ -192,12 +207,27 @@ fun JetPrefAlertDialog(
  */
 object JetPrefAlertDialogDefaults {
     /**
+     * The default title padding for [JetPrefAlertDialog].
+     */
+    val TitlePadding = PaddingValues(start = 24.dp, top = 24.dp, end = 24.dp, bottom = 16.dp)
+
+    /**
      * The default content padding for [JetPrefAlertDialog].
      */
-    val ContentPadding = PaddingValues(horizontal = 24.dp)
+    val ContentPadding = PaddingValues(start = 24.dp, top = 0.dp, end = 24.dp, bottom = 0.dp)
+
+    /**
+     * The default buttons padding for [JetPrefAlertDialog].
+     */
+    val ButtonsPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 8.dp)
+
+    /**
+     * The minimum dialog width for [JetPrefAlertDialog].
+     */
+    val MinDialogWidth = 280.dp
 
     /**
      * The maximum dialog width for [JetPrefAlertDialog].
      */
-    val MaxDialogWidth = 320.dp
+    val MaxDialogWidth = 560.dp
 }


### PR DESCRIPTION
This PR adds a new preference: TextFieldPreference. It allows to directly edit a string pref value and also offers transform and validation capabilities.

The default JetPrefAlertDialog style has changed and is now more in accordance to the [M3 Spec](https://m3.material.io/components/dialogs/overview).

Other improvements include a clean-up of existing implementations, addition of 2 helpers in the `material-ui` package and adding missing documentation.