### PR TITLE
Rework color picker and add 2 utility material3 composables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JetPref [![Maven Central Version](https://img.shields.io/maven-central/v/dev.patrickgold.jetpref/jetpref-datastore-model)](https://mvnrepository.com/search?q=dev.patrickgold.jetpref)
 
 A preference library (custom data handling + UI in JetPack Compose) for Android 6.0+ mainly developed for use in
-[FlorisBoard](https://github.com/florisboard/florisboard). Currently in beta phase.
+[FlorisBoard](https://github.com/florisboard/florisboard).
 
 Disclaimer: This library is still in beta and therefore should only be used with caution in production code. It is
 currently tested out in FlorisBoard, so bugs or other issues in runtime use can be found and fixed. Feel free to ask if
@@ -390,8 +390,12 @@ JetPref additionally provides ready-to-use custom Material components Jetpack Co
   Advanced and easy-to-use alert dialog, based on Jetpack Compose's `Dialog`.
 - [`JetPrefColorPicker`](material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/JetPrefColorPicker.kt): Simple
   but effective HSV color picker.
+- [`JetPrefDropdown`](material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/JetPrefDropdown.kt): Ease of use
+- of a material3 dropdown.
 - [`JetPrefListItem`](material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/JetPrefListItem.kt): Compatibility
   and ease-of use for a list item.
+- [`JetPrefTextField`](material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/JetPrefDropdown.kt): Ease of use
+- of material3 text field, which allow to toggle filled/outlined appearance via parameters.
 
 The Material UI package can be used independently from JetPref too, if you only need one of the above components!
 
@@ -406,7 +410,7 @@ A separate documentation page (with dokka) for the API and improved tutorials / 
 ## License
 
 ```
-Copyright 2021-2024 Patrick Goldinger
+Copyright 2021-2025 Patrick Goldinger
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Patrick Goldinger
+ * Copyright (C) 2022-2025 Patrick Goldinger
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/datastore-annotations/build.gradle.kts
+++ b/datastore-annotations/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Patrick Goldinger
+ * Copyright 2022-2025 Patrick Goldinger
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/datastore-model/build.gradle.kts
+++ b/datastore-model/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Patrick Goldinger
+ * Copyright 2022-2025 Patrick Goldinger
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,9 +55,10 @@ dependencies {
     implementation(libs.kotlinx.coroutines)
     implementation(project(":datastore-annotations"))
 
-    testImplementation(libs.kotest.assertions.core)
-    testImplementation(libs.kotest.property)
-    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlin.test.junit5)
 }
 
 tasks.withType<Test> {

--- a/datastore-model/src/test/kotlin/dev/patrickgold/jetpref/datastore/model/StringEncoderTest.kt
+++ b/datastore-model/src/test/kotlin/dev/patrickgold/jetpref/datastore/model/StringEncoderTest.kt
@@ -1,10 +1,10 @@
 package dev.patrickgold.jetpref.datastore.model
 
-import io.kotest.core.spec.style.FreeSpec
-import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
-class StringEncoderTest : FreeSpec({
-    val stringsToTest = listOf(
+class StringEncoderTest {
+    private val stringsToTest = listOf(
         "test" to "\"test\"",
         "\r\n" to "\"\\r\\n\"",
         "\\" to "\"\\\\\"",
@@ -14,20 +14,17 @@ class StringEncoderTest : FreeSpec({
         "\\\"one\\\" two=\"hello\"" to "\"\\\\\\\"one\\\\\\\" two=\\\"hello\\\"\"",
     )
 
-    "String encode/decode" - {
-        "Test string encode" - {
-            stringsToTest.forEach { (original, encoded) ->
-                "`$original` should be `$encoded`" {
-                    StringEncoder.encode(original) shouldBe encoded
-                }
-            }
-        }
-        "Test string decode" - {
-            stringsToTest.forEach { (original, encoded) ->
-                "`$encoded` should be `$original`" {
-                    StringEncoder.decode(encoded) shouldBe original
-                }
-            }
+    @Test
+    fun `test string encode`() {
+        stringsToTest.forEach { (original, encoded) ->
+            assertEquals(encoded, StringEncoder.encode(original))
         }
     }
-})
+
+    @Test
+    fun `test string decode`() {
+        stringsToTest.forEach { (original, encoded) ->
+            assertEquals(original, StringEncoder.decode(encoded))
+        }
+    }
+}

--- a/datastore-ui/build.gradle.kts
+++ b/datastore-ui/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Patrick Goldinger
+ * Copyright 2022-2025 Patrick Goldinger
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/TextFieldPreference.kt
+++ b/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/TextFieldPreference.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Patrick Goldinger
+ * Copyright 2024-2025 Patrick Goldinger
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package dev.patrickgold.jetpref.datastore.ui
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -30,6 +29,8 @@ import dev.patrickgold.jetpref.datastore.model.PreferenceData
 import dev.patrickgold.jetpref.datastore.model.PreferenceDataEvaluator
 import dev.patrickgold.jetpref.datastore.model.observeAsState
 import dev.patrickgold.jetpref.material.ui.JetPrefAlertDialog
+import dev.patrickgold.jetpref.material.ui.JetPrefTextField
+import dev.patrickgold.jetpref.material.ui.JetPrefTextFieldDefaults
 import dev.patrickgold.jetpref.material.ui.whenNotNullOrBlank
 
 /**
@@ -125,11 +126,12 @@ fun TextFieldPreference(
                         error.localizedMessage ?: error.message
                     }
                 }
-                OutlinedTextField(
+                JetPrefTextField(
                     value = localPrefValue,
                     onValueChange = { localPrefValue = it },
                     isError = validationResult.isFailure,
                     supportingText = whenNotNullOrBlank(message) { Text(it) },
+                    appearance = JetPrefTextFieldDefaults.outlined(),
                 )
             }
         }

--- a/example/src/main/kotlin/dev/patrickgold/jetpref/example/ui/settings/ColorPickerDemoScreen.kt
+++ b/example/src/main/kotlin/dev/patrickgold/jetpref/example/ui/settings/ColorPickerDemoScreen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Patrick Goldinger
+ * Copyright 2022-2025 Patrick Goldinger
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,11 @@
 package dev.patrickgold.jetpref.example.ui.settings
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -30,7 +29,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
+import androidx.core.graphics.ColorUtils
 import dev.patrickgold.jetpref.datastore.ui.ScrollablePreferenceLayout
 import dev.patrickgold.jetpref.example.examplePreferenceModel
 import dev.patrickgold.jetpref.material.ui.ExperimentalJetPrefMaterial3Ui
@@ -40,42 +41,26 @@ import dev.patrickgold.jetpref.material.ui.rememberJetPrefColorPickerState
 
 @OptIn(ExperimentalJetPrefMaterial3Ui::class)
 @Composable
-fun ColorPickerDemoScreen() = ScrollablePreferenceLayout(examplePreferenceModel()) {
-    var color by remember { mutableStateOf(Color.White) }
-    Column(modifier = Modifier.padding(all = 32.dp)) {
+fun ColorPickerDemoScreen() = ScrollablePreferenceLayout(
+    cachedPrefModel = examplePreferenceModel(),
+    modifier = Modifier.fillMaxSize(),
+) {
+    var color by remember { mutableStateOf(Color.Red) }
+    Column(modifier = Modifier.padding(all = 16.dp)) {
         val colorPickerState = rememberJetPrefColorPickerState(initColor = color)
 
         Surface(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = 32.dp)
+                .padding(bottom = 16.dp)
                 .checkeredBackground(),
             color = color,
         ) {
-            Text(text = "Color state outside the picker.")
-        }
-
-        Row {
-            TextButton(onClick = {
-                colorPickerState.setColor(Color.Red)
-                color = Color.Red
-            }) {
-                Text(text = "Red")
-            }
-
-            TextButton(onClick = {
-                colorPickerState.setColor(Color.Green)
-                color = Color.Green
-            }) {
-                Text(text = "Green")
-            }
-
-            TextButton(onClick = {
-                colorPickerState.setColor(Color.Blue)
-                color = Color.Blue
-            }) {
-                Text(text = "Blue")
-            }
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = "Color state outside the picker.",
+                color = if (ColorUtils.calculateLuminance(color.toArgb()) > 0.179f) Color.Black else Color.White,
+            )
         }
 
         JetPrefColorPicker(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ kotlinx-coroutines = "1.8.1"
 vanniktech-maven-publish = "0.29.0"
 
 # Testing
-kotest = "5.4.0"
+junit-jupiter = "5.10.1"
 
 [libraries]
 # Main
@@ -30,9 +30,10 @@ androidx-navigation-compose = { module = "androidx.navigation:navigation-compose
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 
 # Testing
-kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
-kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
-kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit-jupiter" }
+junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit-jupiter" }
+kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
+kotlin-test-junit5 = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit5", version.ref = "kotlin" }
 
 [plugins]
 # Main

--- a/material-ui/build.gradle.kts
+++ b/material-ui/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Patrick Goldinger
+ * Copyright 2022-2025 Patrick Goldinger
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,15 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
 
     debugImplementation(libs.androidx.compose.ui.tooling)
+
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlin.test.junit5)
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }
 
 val sourcesJar = tasks.register<Jar>("sourcesJar") {

--- a/material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/ColorRepresentation.kt
+++ b/material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/ColorRepresentation.kt
@@ -47,7 +47,7 @@ enum class ColorRepresentation(val regex: Regex) {
             }
             HSV -> {
                 val (h, s, v, a) = color.toHsv()
-                val hsv = listOf(h.toInt(), (s * 100).toInt(), (v * 100).toInt()).joinToString(", ")
+                val hsv = listOf(h.roundToInt(), (s * 100).roundToInt(), (v * 100).roundToInt()).joinToString(", ")
                 if (withAlpha) {
                     val alphaStr = String.format(Locale.ROOT, "%.2f", a).trimEnd('0').trimEnd('.')
                     "hsva($hsv, $alphaStr)"

--- a/material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/ColorRepresentation.kt
+++ b/material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/ColorRepresentation.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.jetpref.material.ui
+
+import androidx.compose.ui.graphics.Color
+import java.util.Locale
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+enum class ColorRepresentation(val regex: Regex) {
+    HEX(regex = RegexHelpers.HEX),
+    RGB(regex = RegexHelpers.RGB),
+    HSV(regex = RegexHelpers.HSV);
+
+    fun formatColor(color: Color, withAlpha: Boolean): String {
+        return when (this) {
+            HEX -> {
+                val (r, g, b, a) = color.toRgb()
+                val components = if (withAlpha) listOf(r, g, b, (a * 255).roundToInt()) else listOf(r, g, b)
+                "#" + components.joinToString("") {
+                    String.format(Locale.ROOT, "%02x", it)
+                }
+            }
+            RGB -> {
+                val (r, g, b, a) = color.toRgb()
+                if (withAlpha) {
+                    val alphaStr = String.format(Locale.ROOT, "%.2f", a).trimEnd('0').trimEnd('.')
+                    "rgba($r, $g, $b, $alphaStr)"
+                } else {
+                    "rgb($r, $g, $b)"
+                }
+            }
+            HSV -> {
+                val (h, s, v, a) = color.toHsv()
+                val hsv = listOf(h.toInt(), (s * 100).toInt(), (v * 100).toInt()).joinToString(", ")
+                if (withAlpha) {
+                    val alphaStr = String.format(Locale.ROOT, "%.2f", a).trimEnd('0').trimEnd('.')
+                    "hsva($hsv, $alphaStr)"
+                } else {
+                    "hsv($hsv)"
+                }
+            }
+        }
+    }
+
+    @Suppress("ConstPropertyName")
+    private object RegexHelpers {
+        private const val HexDigit = "[0-9a-fA-F]"
+        private const val Separator = "\\s*,\\s*"
+        private const val ParenOpen = "\\(\\s*"
+        private const val ParenClose = "\\s*\\)"
+        private const val Float1Dot0 = "1(?:\\.0)?|0(?:\\.[0-9]+)?|\\.[0-9]+"
+        private const val Int255 = "25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9]"
+        private const val Rgb = "(?<r>$Int255)$Separator(?<g>$Int255)$Separator(?<b>$Int255)(?:$Separator(?<a>$Float1Dot0))?"
+        private const val Int360 = "360|3[0-5][0-9]|[1-2][0-9][0-9]|[1-9]?[0-9]"
+        private const val Int100 = "100|[1-9]?[0-9]"
+        private const val Hsv = "(?<h>$Int360)$Separator(?<s>$Int100)$Separator(?<v>$Int100)(?:$Separator(?<a>$Float1Dot0))?"
+
+        val HEX = "^#(?<r>$HexDigit{2})(?<g>$HexDigit{2})(?<b>$HexDigit{2})(?<a>$HexDigit{2})?\$".toRegex()
+        val RGB = "^[rR][gG][bB][aA]?$ParenOpen$Rgb$ParenClose\$".toRegex()
+        val HSV = "^[hH][sS][vV][aA]?$ParenOpen$Hsv$ParenClose\$".toRegex()
+    }
+}
+
+internal data class HsvColor(
+    val hue: Float,
+    val saturation: Float,
+    val value: Float,
+    val alpha: Float,
+)
+
+internal fun Color.toHsv(): HsvColor {
+    val r = this.red
+    val g = this.green
+    val b = this.blue
+
+    val cMax = max(r, max(g, b))
+    val cMin = min(r, min(g, b))
+    val diff = cMax - cMin
+
+    val h = when (cMax) {
+        cMin -> 0f
+        r -> (60 * ((g - b) / diff) + 360) % 360
+        g -> (60 * ((b - r) / diff) + 120) % 360
+        b -> (60 * ((r - g) / diff) + 240) % 360
+        else -> -1f
+    }
+    val s = if (cMax == 0f) { 0f } else { diff / cMax }
+
+    return HsvColor(h, s, cMax, this.alpha)
+}
+
+internal data class RgbColor(
+    val red: Int,
+    val green: Int,
+    val blue: Int,
+    val alpha: Float,
+)
+
+internal fun Color.toRgb(): RgbColor {
+    return RgbColor(
+        red = (this.red * 255).roundToInt(),
+        green = (this.green * 255).roundToInt(),
+        blue = (this.blue * 255).roundToInt(),
+        alpha = this.alpha,
+    )
+}
+
+fun Color.Companion.parseOrNull(str: String, withAlpha: Boolean): Pair<Color, ColorRepresentation>? {
+    val trimmed = str.trim()
+
+    for (representation in ColorRepresentation.entries) {
+        val regex = representation.regex
+        val match = regex.matchEntire(trimmed) ?: continue
+        if (!withAlpha && match.groups["a"] != null) break
+        when (representation) {
+            ColorRepresentation.HEX -> {
+                val r = match.groups["r"]!!.value.toInt(16) / 255f
+                val g = match.groups["g"]!!.value.toInt(16) / 255f
+                val b = match.groups["b"]!!.value.toInt(16) / 255f
+                val a = match.groups["a"]?.value?.toInt(16)?.div(255f) ?: 1f
+                return Color(r, g, b, a) to representation
+            }
+            ColorRepresentation.RGB -> {
+                val r = match.groups["r"]!!.value.toInt() / 255f
+                val g = match.groups["g"]!!.value.toInt() / 255f
+                val b = match.groups["b"]!!.value.toInt() / 255f
+                val a = match.groups["a"]?.value?.toFloat() ?: 1f
+                return Color(r, g, b, a) to representation
+            }
+            ColorRepresentation.HSV -> {
+                val h = match.groups["h"]!!.value.toFloat()
+                val s = match.groups["s"]!!.value.toFloat() / 100f
+                val v = match.groups["v"]!!.value.toFloat() / 100f
+                val a = match.groups["a"]?.value?.toFloat() ?: 1f
+                return hsv(h, s, v, a) to representation
+            }
+        }
+    }
+
+    return null
+}

--- a/material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/JetPrefDropdown.kt
+++ b/material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/JetPrefDropdown.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2025 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.jetpref.material.ui
+
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+
+/**
+ * A dropdown that allows the user to select an option from a list of options.
+ *
+ * @param options The list of options to choose from.
+ * @param selectedOptionIndex The index of the currently selected option.
+ * @param onSelectOption The callback that is called when an option is selected.
+ * @param modifier The modifier to apply to the layout.
+ * @param expanded The state of the dropdown menu.
+ * @param enabled Whether the dropdown menu is enabled.
+ * @param isError Whether the dropdown menu is in an error state.
+ * @param labelText The text to display as the label of the dropdown menu. Ignored if
+ *  [label] is provided.
+ * @param label The composable to display as the label of the dropdown menu.
+ * @param optionsLabelProvider A function that provides a label for each option. If not
+ *  provided, the options will be converted to strings using `toString`.
+ * @param appearance The appearance of the dropdown menu.
+ *
+ * @since 0.2.0
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun <T : Any> JetPrefDropdown(
+    options: List<T>,
+    selectedOptionIndex: Int,
+    onSelectOption: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    expanded: MutableState<Boolean> = rememberJetPrefDropdownExpandedState(),
+    enabled: Boolean = true,
+    isError: Boolean = false,
+    labelText: String? = null,
+    label: @Composable (() -> Unit)? = null,
+    optionsLabelProvider: ((T) -> String)? = null,
+    appearance: JetPrefTextFieldAppearance = JetPrefDropdownMenuDefaults.filled(),
+) {
+    fun asString(v: T): String {
+        return optionsLabelProvider?.invoke(v) ?: v.toString()
+    }
+
+    ExposedDropdownMenuBox(
+        modifier = modifier,
+        expanded = expanded.value,
+        onExpandedChange = {
+            if (enabled) {
+                expanded.value = it
+            }
+        },
+    ) {
+        JetPrefTextField(
+            modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable),
+            value = asString(options[selectedOptionIndex]),
+            onValueChange = {},
+            enabled = enabled,
+            readOnly = true,
+            isError = isError,
+            singleLine = true,
+            labelText = labelText,
+            label = label,
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded.value) },
+            appearance = appearance,
+        )
+        ExposedDropdownMenu(
+            expanded = expanded.value,
+            onDismissRequest = { expanded.value = false },
+        ) {
+            options.forEachIndexed { index, option ->
+                DropdownMenuItem(
+                    text = { Text(asString(option), style = MaterialTheme.typography.bodyLarge) },
+                    onClick = {
+                        onSelectOption(index)
+                        expanded.value = false
+                    },
+                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Contains the default values used by [JetPrefDropdown].
+ *
+ * @since 0.2.0
+ */
+object JetPrefDropdownMenuDefaults {
+    /**
+     * Creates a filled [JetPrefTextFieldAppearance] with provided shape and color
+     * for usage in [JetPrefDropdown].
+     *
+     * @since 0.2.0
+     */
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    fun filled(
+        shape: Shape = TextFieldDefaults.shape,
+        colors: TextFieldColors = ExposedDropdownMenuDefaults.textFieldColors(),
+    ) = JetPrefTextFieldDefaults.filled(shape, colors)
+
+    /**
+     * Creates an outlined [JetPrefTextFieldAppearance] with provided shape and color
+     * for usage in [JetPrefDropdown].
+     *
+     * @since 0.2.0
+     */
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    fun outlined(
+        shape: Shape = TextFieldDefaults.shape,
+        colors: TextFieldColors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
+    ) = JetPrefTextFieldDefaults.outlined(shape, colors)
+}
+
+/**
+ * Remembers a [MutableState] for the expanded state of a [JetPrefDropdown].
+ *
+ * @since 0.2.0
+ */
+@Composable
+fun rememberJetPrefDropdownExpandedState(
+    initialValue: Boolean = false,
+): MutableState<Boolean> {
+    return remember { mutableStateOf(initialValue) }
+}

--- a/material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/JetPrefTextField.kt
+++ b/material-ui/src/main/kotlin/dev/patrickgold/jetpref/material/ui/JetPrefTextField.kt
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2025 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.jetpref.material.ui
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextOverflow
+
+/**
+ * A text field wrapper allowing to dynamically switch between filled and outlined.
+ * See the original documentation for [TextField] and [OutlinedTextField] for more information.
+ *
+ * @since 0.2.0
+ *
+ * @see androidx.compose.material3.TextField
+ * @see androidx.compose.material3.OutlinedTextField
+ */
+@Composable
+fun JetPrefTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = LocalTextStyle.current,
+    labelText: String? = null,
+    label: @Composable (() -> Unit)? = null,
+    placeholderText: String? = null,
+    placeholder: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    prefix: @Composable (() -> Unit)? = null,
+    suffix: @Composable (() -> Unit)? = null,
+    supportingText: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    interactionSource: MutableInteractionSource? = null,
+    appearance: JetPrefTextFieldAppearance = JetPrefTextFieldDefaults.filled(),
+) {
+    val labelComposable = label ?: labelText?.let { {
+        Text(text = it, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    } }
+    val placeholderComposable = placeholder ?: placeholderText?.let { {
+        Text(text = it, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    } }
+
+    when (appearance.style) {
+        JetPrefTextFieldStyle.Filled -> {
+            TextField(
+                value,
+                onValueChange,
+                modifier,
+                enabled,
+                readOnly,
+                textStyle,
+                labelComposable,
+                placeholderComposable,
+                leadingIcon,
+                trailingIcon,
+                prefix,
+                suffix,
+                supportingText,
+                isError,
+                visualTransformation,
+                keyboardOptions,
+                keyboardActions,
+                singleLine,
+                maxLines,
+                minLines,
+                interactionSource,
+                appearance.shape,
+                appearance.colors,
+            )
+        }
+        JetPrefTextFieldStyle.Outlined -> {
+            OutlinedTextField(
+                value,
+                onValueChange,
+                modifier,
+                enabled,
+                readOnly,
+                textStyle,
+                labelComposable,
+                placeholderComposable,
+                leadingIcon,
+                trailingIcon,
+                prefix,
+                suffix,
+                supportingText,
+                isError,
+                visualTransformation,
+                keyboardOptions,
+                keyboardActions,
+                singleLine,
+                maxLines,
+                minLines,
+                interactionSource,
+                appearance.shape,
+                appearance.colors,
+            )
+        }
+    }
+}
+
+/**
+ * A text field wrapper allowing to dynamically switch between filled and outlined.
+ * See the original documentation for [TextField] and [OutlinedTextField] for more information.
+ *
+ * @since 0.2.0
+ *
+ * @see androidx.compose.material3.TextField
+ * @see androidx.compose.material3.OutlinedTextField
+ */
+@Composable
+fun JetPrefTextField(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = LocalTextStyle.current,
+    labelText: String? = null,
+    label: @Composable (() -> Unit)? = null,
+    placeholderText: String? = null,
+    placeholder: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    prefix: @Composable (() -> Unit)? = null,
+    suffix: @Composable (() -> Unit)? = null,
+    supportingText: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    interactionSource: MutableInteractionSource? = null,
+    appearance: JetPrefTextFieldAppearance = JetPrefTextFieldDefaults.filled(),
+) {
+    val labelComposable = label ?: labelText?.let { {
+        Text(text = it, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    } }
+    val placeholderComposable = placeholder ?: placeholderText?.let { {
+        Text(text = it, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    } }
+
+    when (appearance.style) {
+        JetPrefTextFieldStyle.Filled -> {
+            TextField(
+                value,
+                onValueChange,
+                modifier,
+                enabled,
+                readOnly,
+                textStyle,
+                labelComposable,
+                placeholderComposable,
+                leadingIcon,
+                trailingIcon,
+                prefix,
+                suffix,
+                supportingText,
+                isError,
+                visualTransformation,
+                keyboardOptions,
+                keyboardActions,
+                singleLine,
+                maxLines,
+                minLines,
+                interactionSource,
+                appearance.shape,
+                appearance.colors,
+            )
+        }
+        JetPrefTextFieldStyle.Outlined -> {
+            OutlinedTextField(
+                value,
+                onValueChange,
+                modifier,
+                enabled,
+                readOnly,
+                textStyle,
+                labelComposable,
+                placeholderComposable,
+                leadingIcon,
+                trailingIcon,
+                prefix,
+                suffix,
+                supportingText,
+                isError,
+                visualTransformation,
+                keyboardOptions,
+                keyboardActions,
+                singleLine,
+                maxLines,
+                minLines,
+                interactionSource,
+                appearance.shape,
+                appearance.colors,
+            )
+        }
+    }
+}
+
+/**
+ * The style of a [JetPrefTextField].
+ *
+ * @since 0.2.0
+ */
+enum class JetPrefTextFieldStyle {
+    Filled,
+    Outlined,
+}
+
+/**
+ * The appearance of a [JetPrefTextField].
+ *
+ * @since 0.2.0
+ */
+data class JetPrefTextFieldAppearance(
+    val style: JetPrefTextFieldStyle,
+    val shape: Shape,
+    val colors: TextFieldColors,
+)
+
+/**
+ * Contains the default values used by [JetPrefTextField].
+ *
+ * @since 0.2.0
+ */
+object JetPrefTextFieldDefaults {
+    /**
+     * Creates a filled [JetPrefTextFieldAppearance] with provided shape and color
+     * for usage in [JetPrefTextField].
+     *
+     * @since 0.2.0
+     */
+    @Composable
+    fun filled(
+        shape: Shape = TextFieldDefaults.shape,
+        colors: TextFieldColors = TextFieldDefaults.colors(),
+    ) = JetPrefTextFieldAppearance(JetPrefTextFieldStyle.Filled, shape, colors)
+
+    /**
+     * Creates an outlined [JetPrefTextFieldAppearance] with provided shape and color
+     * for usage in [JetPrefTextField].
+     *
+     * @since 0.2.0
+     */
+    @Composable
+    fun outlined(
+        shape: Shape = OutlinedTextFieldDefaults.shape,
+        colors: TextFieldColors = OutlinedTextFieldDefaults.colors(),
+    ) = JetPrefTextFieldAppearance(JetPrefTextFieldStyle.Outlined, shape, colors)
+}

--- a/material-ui/src/test/kotlin/dev/patrickgold/jetpref/material/ui/ColorRepresentationTest.kt
+++ b/material-ui/src/test/kotlin/dev/patrickgold/jetpref/material/ui/ColorRepresentationTest.kt
@@ -1,0 +1,243 @@
+package dev.patrickgold.jetpref.material.ui
+
+import androidx.compose.ui.graphics.Color
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+private data class ColorRow(
+    val color: Color,
+    val hex: String,
+    val rgb: String,
+    val hsv: String,
+)
+
+class ColorRepresentationTest {
+    private fun rgba(rgba: Long): Color {
+        val r = ((rgba shr 24) and 0xff).toFloat() / 255
+        val g = ((rgba shr 16) and 0xff).toFloat() / 255
+        val b = ((rgba shr 8) and 0xff).toFloat() / 255
+        val a = (rgba and 0xff).toFloat() / 255
+        return Color(r, g, b, a)
+    }
+
+    private fun rgb(rgb: Long): Color {
+        val r = ((rgb shr 16) and 0xff).toFloat() / 255
+        val g = ((rgb shr 8) and 0xff).toFloat() / 255
+        val b = (rgb and 0xff).toFloat() / 255
+        return Color(r, g, b)
+    }
+
+    private val colorTable = listOf(
+        ColorRow(
+            color = rgb(0xffffff),
+            hex = "#ffffff",
+            rgb = "rgb(255, 255, 255)",
+            hsv = "hsv(0, 0, 100)",
+        ),
+        ColorRow(
+            color = rgb(0x000000),
+            hex = "#000000",
+            rgb = "rgb(0, 0, 0)",
+            hsv = "hsv(0, 0, 0)",
+        ),
+        ColorRow(
+            color = rgb(0x7f7f7f),
+            hex = "#7f7f7f",
+            rgb = "rgb(127, 127, 127)",
+            hsv = "hsv(0, 0, 50)",
+        ),
+        ColorRow(
+            color = rgb(0x123456),
+            hex = "#123456",
+            rgb = "rgb(18, 52, 86)",
+            hsv = "hsv(210, 79, 34)",
+        ),
+        ColorRow(
+            color = rgb(0xabcdef),
+            hex = "#abcdef",
+            rgb = "rgb(171, 205, 239)",
+            hsv = "hsv(210, 28, 94)",
+        ),
+        ColorRow(
+            color = rgb(0x57992c),
+            hex = "#57992c",
+            rgb = "rgb(87, 153, 44)",
+            hsv = "hsv(96, 71, 60)",
+        ),
+        ColorRow(
+            color = rgb(0xaabde2),
+            hex = "#aabde2",
+            rgb = "rgb(170, 189, 226)",
+            hsv = "hsv(220, 25, 89)",
+        ),
+        ColorRow(
+            color = rgb(0x210f18),
+            hex = "#210f18",
+            rgb = "rgb(33, 15, 24)",
+            hsv = "hsv(330, 55, 13)",
+        ),
+        ColorRow(
+            color = rgb(0xa02784),
+            hex = "#a02784",
+            rgb = "rgb(160, 39, 132)",
+            hsv = "hsv(314, 76, 63)",
+        ),
+    )
+
+    @Test
+    fun `test HEX color formatting without alpha`() {
+        colorTable.forEach { (color, expected, _, _) ->
+            assertEquals(expected, ColorRepresentation.HEX.formatColor(color, withAlpha = false))
+        }
+    }
+
+    @Test
+    fun `test RGB color formatting without alpha`() {
+        colorTable.forEach { (color, _, expected, _) ->
+            assertEquals(expected, ColorRepresentation.RGB.formatColor(color, withAlpha = false))
+        }
+    }
+
+    @Test
+    fun `test HSV color formatting without alpha`() {
+        colorTable.forEach { (color, _, _, expected) ->
+            assertEquals(expected, ColorRepresentation.HSV.formatColor(color, withAlpha = false))
+        }
+    }
+
+    @Test
+    fun `test HEX color parsing without alpha`() {
+        for (r in 0..255) {
+            val rStr = String.format("%02x", r)
+            for (g in 0..255) {
+                val gStr = String.format("%02x", g)
+                for (b in 0..255) {
+                    val bStr = String.format("%02x", b)
+                    val expectedColor = Color(r / 255f, g / 255f, b / 255f)
+                    val hexStr = "#$rStr$gStr$bStr"
+                    val result = Color.parseOrNull(hexStr, withAlpha = false)
+                    assertNotNull(result, "Failed to parse $hexStr")
+                    val (actualColor, representation) = result
+                    assertEquals(expectedColor, actualColor)
+                    assertEquals(ColorRepresentation.HEX, representation)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test RGB color parsing without alpha`() {
+        for (r in 0..255) {
+            for (g in 0..255) {
+                for (b in 0..255) {
+                    val expectedColor = Color(r / 255f, g / 255f, b / 255f)
+                    val rgbStr = "rgb($r, $g, $b)"
+                    val result = Color.parseOrNull(rgbStr, withAlpha = false)
+                    assertNotNull(result, "Failed to parse $rgbStr")
+                    val (actualColor, representation) = result
+                    assertEquals(expectedColor, actualColor)
+                    assertEquals(ColorRepresentation.RGB, representation)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test HSV color parsing without alpha`() {
+        for (h in 0..<360) {
+            for (s in 0..100) {
+                for (v in 0..100) {
+                    val expectedColor = Color.hsv(h.toFloat(), s.toFloat() / 100f, v.toFloat() / 100f)
+                    val hsvStr = "hsv($h, $s, $v)"
+                    val result = Color.parseOrNull(hsvStr, withAlpha = false)
+                    assertNotNull(result, "Failed to parse $hsvStr")
+                    val (actualColor, representation) = result
+                    assertEquals(expectedColor, actualColor)
+                    assertEquals(ColorRepresentation.HSV, representation)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `text HEX color parsing with alpha`() {
+        for (r in 0..255 step 4) {
+            val rStr = String.format("%02x", r)
+            for (g in 0..255 step 4) {
+                val gStr = String.format("%02x", g)
+                for (b in 0..255 step 4) {
+                    val bStr = String.format("%02x", b)
+                    for (a in 0..255 step 64) {
+                        val aStr = String.format("%02x", a)
+                        val expectedColor = Color(r / 255f, g / 255f, b / 255f, a / 255f)
+                        val hexStr = "#$rStr$gStr$bStr$aStr"
+                        val result = Color.parseOrNull(hexStr, withAlpha = true)
+                        assertNotNull(result, "Failed to parse $hexStr")
+                        val (actualColor, representation) = result
+                        assertEquals(expectedColor, actualColor)
+                        assertEquals(ColorRepresentation.HEX, representation)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test RGB color parsing with alpha`() {
+        for (r in 0..255 step 4) {
+            for (g in 0..255 step 4) {
+                for (b in 0..255 step 4) {
+                    for (a in 0..255 step 64) {
+                        val expectedColor = Color(r / 255f, g / 255f, b / 255f, a / 255f)
+                        val rgbStr = "rgb($r, $g, $b, ${a / 255f})"
+                        val result = Color.parseOrNull(rgbStr, withAlpha = true)
+                        assertNotNull(result, "Failed to parse $rgbStr")
+                        val (actualColor, representation) = result
+                        assertEquals(expectedColor, actualColor)
+                        assertEquals(ColorRepresentation.RGB, representation)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test HSV color parsing with alpha`() {
+        for (h in 0..<360 step 4) {
+            for (s in 0..100 step 4) {
+                for (v in 0..100 step 4) {
+                    for (a in 0..255 step 64) {
+                        val expectedColor = Color.hsv(h.toFloat(), s.toFloat() / 100f, v.toFloat() / 100f, a / 255f)
+                        val hsvStr = "hsv($h, $s, $v, ${a / 255f})"
+                        val result = Color.parseOrNull(hsvStr, withAlpha = true)
+                        assertNotNull(result, "Failed to parse $hsvStr")
+                        val (actualColor, representation) = result
+                        assertEquals(expectedColor, actualColor)
+                        assertEquals(ColorRepresentation.HSV, representation)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test color parsing for invalid strings`() {
+        val invalidStrings = listOf(
+            "",
+            "#test12",
+            "rgb(-2, 255, 255)",
+            "rgb(256, 255, 255)",
+            "rgb(300, 255, 255)",
+            "rgb(255, -2, 255)",
+            "rgb(0 0 0)",
+            "hsv(389, 100, 100)",
+            "hsv(0, 101, 100)",
+        )
+        invalidStrings.forEach { str ->
+            val result = Color.parseOrNull(str, withAlpha = false)
+            assertNull(result, "Expected parsing fail for $str")
+        }
+    }
+}


### PR DESCRIPTION
This PR fully reworks the `JetPrefColorPicker` and also adds `JetPrefTextField` and `JetPrefDropdownMenu` as convenience composables.