### PR TITLE
Add LocalTimePickerPreference

### DIFF
--- a/datastore-model/build.gradle.kts
+++ b/datastore-model/build.gradle.kts
@@ -53,6 +53,7 @@ android {
 dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.kotlinx.coroutines)
+    implementation(libs.kotlinx.serialization.json)
     implementation(project(":datastore-annotations"))
 
     testImplementation(libs.junit.jupiter.api)

--- a/datastore-model/src/main/kotlin/dev/patrickgold/jetpref/datastore/model/LocalTime.kt
+++ b/datastore-model/src/main/kotlin/dev/patrickgold/jetpref/datastore/model/LocalTime.kt
@@ -1,0 +1,15 @@
+package dev.patrickgold.jetpref.datastore.model
+
+import android.text.format.DateFormat.is24HourFormat
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LocalTime(
+    val hour: Int,
+    val minute: Int,
+) {
+    init {
+        require(hour in 0..23) { "hour must in [0..23] range" }
+        require(minute in 0..59) { "minute must be in [0..59] range" }
+    }
+}

--- a/datastore-model/src/main/kotlin/dev/patrickgold/jetpref/datastore/model/PreferenceModel.kt
+++ b/datastore-model/src/main/kotlin/dev/patrickgold/jetpref/datastore/model/PreferenceModel.kt
@@ -125,6 +125,15 @@ abstract class PreferenceModel(val name: String) {
         return prefData
     }
 
+    protected fun time(
+        @PreferenceKey key: String,
+        default: LocalTime,
+    ): PreferenceData<LocalTime> {
+        val prefData = CustomPreferenceData(this, key, default, TimePreferenceSerializer)
+        registryAdd(prefData)
+        return prefData
+    }
+
     protected inline fun <reified V : Enum<V>> enum(
         @PreferenceKey key: String,
         default: V,

--- a/datastore-model/src/main/kotlin/dev/patrickgold/jetpref/datastore/model/PreferenceSerializer.kt
+++ b/datastore-model/src/main/kotlin/dev/patrickgold/jetpref/datastore/model/PreferenceSerializer.kt
@@ -16,6 +16,8 @@
 
 package dev.patrickgold.jetpref.datastore.model
 
+import kotlinx.serialization.json.Json
+
 /**
  * Interface allowing to implement a custom serializer for [V].
  */
@@ -75,4 +77,10 @@ internal object StringPreferenceSerializer : PreferenceSerializer<String> {
     override fun serialize(value: String): String = value
 
     override fun deserialize(value: String): String = value
+}
+
+internal object TimePreferenceSerializer : PreferenceSerializer<LocalTime> {
+    override fun serialize(value: LocalTime): String = Json.encodeToString(value)
+
+    override fun deserialize(value: String): LocalTime = Json.decodeFromString(value)
 }

--- a/datastore-ui/build.gradle.kts
+++ b/datastore-ui/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     // androidTestImplementation(composeBom)
 
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.icons)
     implementation(libs.androidx.compose.runtime.livedata)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.tooling.preview)

--- a/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/Common.kt
+++ b/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/Common.kt
@@ -16,13 +16,16 @@
 
 package dev.patrickgold.jetpref.datastore.ui
 
+import android.text.format.DateFormat.is24HourFormat
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import dev.patrickgold.jetpref.datastore.model.LocalTime
 
 
 @Composable
@@ -44,3 +47,32 @@ internal fun maybeJetIcon(
         else -> null
     }
 }
+
+
+val LocalTime.isAfternoon
+    get() = hour >= 12
+
+@get:Composable
+val LocalTime.hourForDisplay: Int
+    get() {
+        return when {
+            is24HourFormat(LocalContext.current) -> hour % 24
+            hour % 12 == 0 -> 12
+            isAfternoon -> hour - 12
+            else -> hour
+        }
+    }
+
+@get:Composable
+val LocalTime.stringRepresentation: String
+    get() {
+        return if (is24HourFormat(LocalContext.current)) {
+            "$hourForDisplay:${String.format("%02d", minute)}"
+        } else {
+            if (isAfternoon) {
+                "$hourForDisplay:${String.format("%02d", minute)} PM"
+            } else {
+                "$hourForDisplay:${String.format("%02d", minute)} AM"
+            }
+        }
+    }

--- a/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/LocalTimePickerPreference.kt
+++ b/datastore-ui/src/main/kotlin/dev/patrickgold/jetpref/datastore/ui/LocalTimePickerPreference.kt
@@ -17,12 +17,19 @@
 package dev.patrickgold.jetpref.datastore.ui
 
 import android.text.format.DateFormat.is24HourFormat
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+//TODO: Decide if the icons should be included here or in another module
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Keyboard
+import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.DisplayMode
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.TimeInput
 import androidx.compose.material3.TimePicker
 import androidx.compose.material3.TimePickerState
@@ -59,21 +66,6 @@ fun LocalTimePickerPreference(
     var isDialogOpen by remember { mutableStateOf(false) }
     var displayMode by remember { mutableStateOf(DisplayMode.Picker) }
 
-    fun toggleDisplayMode() {
-        displayMode = when (displayMode) {
-            DisplayMode.Picker -> {
-                DisplayMode.Input
-            }
-            DisplayMode.Input -> {
-                DisplayMode.Picker
-            }
-            else -> {
-                //FFS why is this a value class and not an enum???
-                displayMode
-            }
-        }
-    }
-
     Preference(
         modifier = modifier,
         icon = icon,
@@ -100,28 +92,60 @@ fun LocalTimePickerPreference(
             modifier = Modifier
                 .width(IntrinsicSize.Min)
                 .height(IntrinsicSize.Min),
-            onDismiss = {
-                isDialogOpen = false
-            },
-            onNeutral = ::toggleDisplayMode,
-            neutralLabel = if (displayMode == DisplayMode.Picker) {
-                "Switch to Input"
-            } else {
-                "Switch to Picker"
-            },
+            confirmLabel = dialogStrings.confirmLabel,
             onConfirm = {
                 pref.set(timePickerState.toLocalTime())
                 isDialogOpen = false
             },
-            confirmLabel = dialogStrings.confirmLabel,
             dismissLabel = dialogStrings.dismissLabel,
+            onDismiss = {
+                isDialogOpen = false
+            },
+            neutralLabel = dialogStrings.neutralLabel,
+            onNeutral = {
+                pref.reset()
+                isDialogOpen = false
+            },
             properties = DialogProperties(usePlatformDefaultWidth = false)
         ) {
-            val contentModifier = Modifier.padding(horizontal = 24.dp)
-            when (displayMode) {
-                DisplayMode.Picker -> TimePicker(modifier = contentModifier, state = timePickerState)
-                DisplayMode.Input -> TimeInput(modifier = contentModifier, state = timePickerState)
+            Column {
+                val contentModifier = Modifier.padding(horizontal = 24.dp)
+                when (displayMode) {
+                    DisplayMode.Picker -> TimePicker(modifier = contentModifier, state = timePickerState)
+                    DisplayMode.Input -> TimeInput(modifier = contentModifier, state = timePickerState)
+                }
+                DisplayModeToggleButton(displayMode, onDisplayModeChange = { displayMode = it })
             }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DisplayModeToggleButton(
+    displayMode: DisplayMode,
+    onDisplayModeChange: (DisplayMode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (displayMode) {
+        DisplayMode.Picker -> IconButton(
+            modifier = modifier,
+            onClick = { onDisplayModeChange(DisplayMode.Input) },
+        ) {
+            Icon(
+                imageVector = Icons.Default.Keyboard,
+                contentDescription = "Switch time input to keyboard input",
+            )
+        }
+
+        DisplayMode.Input -> IconButton(
+            modifier = modifier,
+            onClick = { onDisplayModeChange(DisplayMode.Picker) },
+        ) {
+            Icon(
+                imageVector = Icons.Default.Schedule,
+                contentDescription = "Switch time input to time picker",
+            )
         }
     }
 }
@@ -130,5 +154,3 @@ fun LocalTimePickerPreference(
 fun TimePickerState.toLocalTime(): LocalTime {
     return LocalTime(hour = hour, minute = minute)
 }
-// TODO: re-implement a time picker preference which does not depend on the
-//       time picker Android view and core lib desugaring

--- a/example/src/main/kotlin/dev/patrickgold/jetpref/example/AppPrefs.kt
+++ b/example/src/main/kotlin/dev/patrickgold/jetpref/example/AppPrefs.kt
@@ -3,6 +3,7 @@ package dev.patrickgold.jetpref.example
 import android.os.Build
 import androidx.compose.ui.graphics.Color
 import dev.patrickgold.jetpref.datastore.JetPref
+import dev.patrickgold.jetpref.datastore.model.LocalTime
 import dev.patrickgold.jetpref.datastore.model.PreferenceMigrationEntry
 import dev.patrickgold.jetpref.datastore.model.PreferenceModel
 import dev.patrickgold.jetpref.datastore.model.PreferenceSerializer
@@ -115,6 +116,11 @@ class AppPrefs : PreferenceModel("example-app-preferences") {
         val longListPref = string(
             key = "test__long_list",
             default = "str1"
+        )
+
+        val time = time(
+            key = "test__time",
+            default = LocalTime(18, 0)
         )
     }
 

--- a/example/src/main/kotlin/dev/patrickgold/jetpref/example/ui/settings/HomeScreen.kt
+++ b/example/src/main/kotlin/dev/patrickgold/jetpref/example/ui/settings/HomeScreen.kt
@@ -30,6 +30,7 @@ import dev.patrickgold.jetpref.datastore.ui.ColorPickerPreference
 import dev.patrickgold.jetpref.datastore.ui.DialogSliderPreference
 import dev.patrickgold.jetpref.datastore.ui.ExperimentalJetPrefDatastoreUi
 import dev.patrickgold.jetpref.datastore.ui.ListPreference
+import dev.patrickgold.jetpref.datastore.ui.LocalTimePickerPreference
 import dev.patrickgold.jetpref.datastore.ui.Preference
 import dev.patrickgold.jetpref.datastore.ui.PreferenceGroup
 import dev.patrickgold.jetpref.datastore.ui.ScrollablePreferenceLayout
@@ -311,5 +312,9 @@ fun HomeScreen() = ScrollablePreferenceLayout(examplePreferenceModel()) {
                 "String 10"
             )
         }
+    )
+    LocalTimePickerPreference(
+        pref = prefs.example.time,
+        title = "Test time"
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ androidx-lifecycle = "2.9.0"
 androidx-navigation = "2.9.0"
 kotlin = "2.1.20"
 kotlinx-coroutines = "1.10.2"
+kotlinx-serialization = "1.9.0"
 vanniktech-maven-publish = "0.32.0"
 
 # Testing
@@ -27,6 +28,7 @@ androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 
 # Testing
 junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit-jupiter" }


### PR DESCRIPTION
This PR lays the foundation for the follow time feature for the FlorisBoard themes by adding the new `LocalTime` and the new `LocalTimePickerPreference`. 