### PR TITLE
Upgrade to AGP 8.13.2 & Upgrade deps

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,6 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kover) apply false
     alias(libs.plugins.agp.application) apply false
-    alias(libs.plugins.agp.multiplatform.library) apply false
+    alias(libs.plugins.agp.library.multiplatform) apply false
     alias(libs.plugins.vanniktech.maven.publish) apply false
 }

--- a/datastore-model-processor/build.gradle.kts
+++ b/datastore-model-processor/build.gradle.kts
@@ -15,9 +15,9 @@ kotlin {
     sourceSets {
         jvmMain {
             dependencies {
-                implementation(libs.ksp.api)
                 implementation(libs.kotlinpoet)
                 implementation(libs.kotlinpoet.ksp)
+                implementation(libs.ksp.api)
             }
         }
     }

--- a/datastore-model/build.gradle.kts
+++ b/datastore-model/build.gradle.kts
@@ -3,10 +3,9 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.agp.library.multiplatform)
+    alias(libs.plugins.kover)
     alias(libs.plugins.ksp)
-    // Disable kover until kotin/kotlinx-kover#772 is fixed
-    // alias(libs.plugins.kover)
-    alias(libs.plugins.agp.multiplatform.library)
     alias(libs.plugins.vanniktech.maven.publish)
 }
 

--- a/datastore-ui/build.gradle.kts
+++ b/datastore-ui/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.plugin.compose)
-    alias(libs.plugins.agp.multiplatform.library)
+    alias(libs.plugins.agp.library.multiplatform)
     alias(libs.plugins.compose.multiplatform)
     alias(libs.plugins.vanniktech.maven.publish)
 }
@@ -33,10 +33,10 @@ kotlin {
     sourceSets {
         androidMain {
             dependencies {
-                implementation(compose.material3)
-                implementation(compose.materialIconsExtended)
-                implementation(compose.runtime)
-                implementation(compose.ui)
+                implementation(libs.jetbrains.compose.material3)
+                implementation(libs.jetbrains.compose.material.icons.extended)
+                implementation(libs.jetbrains.compose.runtime)
+                implementation(libs.jetbrains.compose.ui)
                 implementation(libs.androidx.core.ktx)
                 implementation(projects.datastoreModel)
                 implementation(projects.materialUi)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,18 @@
 [versions]
-android-gradle-plugin = "8.12.3"
-androidx-activity = "1.12.2"
-androidx-compose-bom = "2025.12.01"
+agp = "8.13.2"
+androidx-activity = "1.12.3"
+androidx-compose-bom = "2026.01.01"
 androidx-core = "1.17.0"
 androidx-lifecycle = "2.10.0"
-androidx-navigation = "2.9.6"
-compose-multiplatform = "1.9.3"
+androidx-navigation = "2.9.7"
+compose-multiplatform = "1.10.1"
 junit-jupiter = "5.13.4"
-kotlin = "2.3.0"
+kotlin = "2.3.10"
 kotlinpoet = "2.2.0"
 kotlinx-coroutines = "1.10.2"
-kover = "0.9.4"
-ksp = "2.3.4"
-vanniktech-maven-publish = "0.35.0"
+kover = "0.9.6"
+ksp = "2.3.5"
+vanniktech-maven-publish = "0.36.0"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
@@ -25,6 +25,10 @@ androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
+jetbrains-compose-material3 = { module = "org.jetbrains.compose.material3:material3", version = "1.9.0" }
+jetbrains-compose-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version = "1.7.3" }
+jetbrains-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-multiplatform" }
+jetbrains-compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-multiplatform" }
 junit-jupiter-api = {  module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
 junit-jupiter-params = {  module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
@@ -35,8 +39,8 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 
 [plugins]
-agp-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
-agp-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "android-gradle-plugin" }
+agp-application = { id = "com.android.application", version.ref = "agp" }
+agp-library-multiplatform = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=72f44c9f8ebcb1af43838f45ee5c4aa9c5444898b3468ab3f4af7b6076c5bc3f
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionSha256Sum=b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/material-ui/build.gradle.kts
+++ b/material-ui/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.plugin.compose)
-    alias(libs.plugins.agp.multiplatform.library)
+    alias(libs.plugins.agp.library.multiplatform)
     alias(libs.plugins.compose.multiplatform)
     alias(libs.plugins.vanniktech.maven.publish)
 }
@@ -33,10 +33,10 @@ kotlin {
     sourceSets {
         androidMain {
             dependencies {
-                implementation(compose.material3)
-                implementation(compose.materialIconsExtended)
-                implementation(compose.runtime)
-                implementation(compose.ui)
+                implementation(libs.jetbrains.compose.material3)
+                implementation(libs.jetbrains.compose.material.icons.extended)
+                implementation(libs.jetbrains.compose.runtime)
+                implementation(libs.jetbrains.compose.ui)
             }
         }
         getByName("androidHostTest") {


### PR DESCRIPTION
This PR upgrades to AGP 8.13.2, upgrades other dependencies, and fixes deprecated Gradle usages